### PR TITLE
Added Cedula de la Identidad validator for Paraguay

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ export const personValidators: Record<string, Validator[]> = {
   PK: [PK.cnic],
   PL: [PL.pesel],
   PT: [PT.nif],
-  PY: [PY.ruc],
+  PY: [PY.ruc, PY.cedula],
   RO: [RO.cnp],
   RS: [RS.jmbg],
   RU: [RU.inn],

--- a/src/kr/rrn.spec.ts
+++ b/src/kr/rrn.spec.ts
@@ -14,10 +14,10 @@ describe('kr/rrn', () => {
     expect(result.isValid && result.compact).toEqual('9710139019902');
   });
 
-  it('validate:850529-5920042', () => {
-    const result = validate('8505295920042');
+  it('validate:850126-6401473', () => {
+    const result = validate('8501266401473');
 
-    expect(result.isValid && result.compact).toEqual('8505295920042');
+    expect(result.isValid && result.compact).toEqual('8501266401473');
   });
 
   it('validate:12345678', () => {

--- a/src/py/cedula.spec.ts
+++ b/src/py/cedula.spec.ts
@@ -1,0 +1,46 @@
+import { validate, format } from './cedula';
+import { InvalidComponent, InvalidLength } from '../exceptions';
+
+describe('py/ci', () => {
+  it('format:6.001.234', () => {
+    const result = format('6.001.234');
+
+    expect(result).toEqual('6001234');
+  });
+
+  it('validate:15000', () => {
+    const result = validate('15000');
+
+    expect(result.isValid && result.compact).toEqual('15000');
+  });
+
+  it('validate:3 785 123', () => {
+    const result = validate('3 785 123');
+
+    expect(result.isValid && result.compact).toEqual('3785123');
+  });
+
+  it('validate:6-001-234', () => {
+    const result = validate('6-001-234');
+
+    expect(result.isValid && result.compact).toEqual('6001234');
+  });
+
+  it('validate:660.3', () => {
+    const result = validate('660.3');
+
+    expect(result.error).toBeInstanceOf(InvalidLength);
+  });
+
+  it('validate:26601234', () => {
+    const result = validate('26601234');
+
+    expect(result.error).toBeInstanceOf(InvalidLength);
+  });
+
+  it('validate:266012A', () => {
+    const result = validate('266012A');
+
+    expect(result.error).toBeInstanceOf(InvalidComponent);
+  });
+});

--- a/src/py/cedula.ts
+++ b/src/py/cedula.ts
@@ -1,0 +1,79 @@
+/**
+ *
+ * Paraguay Identity Card numbers
+ *
+ * CI number (Cedula de la Identidad Civil).
+ *
+ * The Cedula de la Identidad (CI) is issued by the National Police and is compulsory for all citizens
+ *
+ * The CI number is 5-7 digits.
+ *
+ * Sources:
+ *     https://es.wikipedia.org/wiki/C%C3%A9dula_de_Identidad_(Paraguay)
+ *
+ * PERSON
+ */
+
+import * as exceptions from '../exceptions';
+import { strings } from '../util';
+import { Validator, ValidateReturn } from '../types';
+
+function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
+  return strings.cleanUnicode(input, ' .-');
+}
+
+const impl: Validator = {
+  name: 'Paraguay CI Number',
+  localName: 'Cedula de la Identidad civil',
+  abbreviation: 'CI',
+  compact(input: string): string {
+    const [value, err] = clean(input);
+
+    if (err) {
+      throw err;
+    }
+
+    return value;
+  },
+
+  format(input: string): string {
+    const [value] = clean(input);
+
+    return value;
+  },
+
+  /**
+   * Check if the number is a valid CI.
+   * This checks the length, formatting and other contraints.
+   *
+   */
+  validate(input: string): ValidateReturn {
+    const [value, error] = clean(input);
+
+    if (error) {
+      return { isValid: false, error };
+    }
+    if (value.length < 5 || value.length > 7) {
+      return { isValid: false, error: new exceptions.InvalidLength() };
+    }
+    if (!strings.isdigits(value)) {
+      return { isValid: false, error: new exceptions.InvalidComponent() };
+    }
+
+    return {
+      isValid: true,
+      compact: value,
+      isIndividual: true,
+      isCompany: false,
+    };
+  },
+};
+
+export const {
+  name,
+  localName,
+  abbreviation,
+  validate,
+  format,
+  compact,
+} = impl;

--- a/src/py/index.ts
+++ b/src/py/index.ts
@@ -1,1 +1,2 @@
 export * as ruc from './ruc';
+export * as cedula from './cedula';


### PR DESCRIPTION
Adding Cedula de la Identidad (Identity Card) validator for Paraguay

The vanilla rules for CI number is 5-7 digits - the format is pure digit string no dot/dash/spaces
