### PR TITLE
Do not pad NL identifiers to a length of 9 in clean

### DIFF
--- a/src/nl/bsn.spec.ts
+++ b/src/nl/bsn.spec.ts
@@ -32,4 +32,10 @@ describe('nl/bsn', () => {
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });
+
+  it('validate:1', () => {
+    const result = validate('1');
+
+    expect(result.error).toBeInstanceOf(InvalidLength);
+  });
 });

--- a/src/nl/bsn.ts
+++ b/src/nl/bsn.ts
@@ -20,13 +20,7 @@ import { Validator, ValidateReturn } from '../types';
 import { weightedSum } from '../util/checksum';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
-  const [value, err] = strings.cleanUnicode(input, ' -.');
-
-  if (err) {
-    return [value, err];
-  }
-
-  return [value.padStart(9, '0'), null];
+  return strings.cleanUnicode(input, ' -.');
 }
 
 const impl: Validator = {

--- a/src/nl/onderwijsnummer.spec.ts
+++ b/src/nl/onderwijsnummer.spec.ts
@@ -25,4 +25,10 @@ describe('nl/onderwijsnummer', () => {
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });
+
+  it('validate:1', () => {
+    const result = validate('1');
+
+    expect(result.error).toBeInstanceOf(InvalidLength);
+  });
 });

--- a/src/nl/onderwijsnummer.ts
+++ b/src/nl/onderwijsnummer.ts
@@ -17,13 +17,7 @@ import { Validator, ValidateReturn } from '../types';
 import { weightedSum } from '../util/checksum';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
-  const [value, err] = strings.cleanUnicode(input, ' -.');
-
-  if (err) {
-    return [value, err];
-  }
-
-  return [value.padStart(9, '0'), null];
+  return strings.cleanUnicode(input, ' -.');
 }
 
 const impl: Validator = {


### PR DESCRIPTION
For [#17](https://github.com/koblas/stdnum-js/issues/17)