### PR TITLE
feat: add belgian national number

### DIFF
--- a/src/be/nn.spec.ts
+++ b/src/be/nn.spec.ts
@@ -1,0 +1,127 @@
+import { validate, format } from './nn';
+import { InvalidLength, InvalidChecksum, InvalidFormat } from '../exceptions';
+
+describe('be/nn', () => {
+  it('format:88 02 29-999.90', () => {
+    const result = format('88 02 29-999.90');
+
+    expect(result).toEqual('88022999990');
+  });
+
+  it('format:88022999990', () => {
+    const result = format('88022999990');
+
+    expect(result).toEqual('88022999990');
+  });
+
+  it('validate:1', () => {
+    const result = validate('1');
+
+    expect(result.error).toBeInstanceOf(InvalidLength);
+  });
+
+  it('validate:88022999990', () => {
+    const result = validate('88022999990');
+
+    expect(result.isValid && result.compact).toEqual('88022999990');
+  });
+
+  it('validate:88022999991', () => {
+    const result = validate('88022999991');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:87022999991', () => {
+    const result = validate('87022999991');
+
+    expect(result.error).toBeInstanceOf(InvalidFormat);
+  });
+
+  it('validate:88022999297', () => {
+    const result = validate('88022999297');
+
+    expect(result.isValid && result.compact).toEqual('88022999297')
+  });
+
+  it('validate:85073003328', () => {
+    const result = validate('85073003328');
+
+    expect(result.isValid && result.compact).toEqual('85073003328');
+  });
+
+  it('validate:20070199922', () => {
+    const result = validate('20070199922');
+
+    expect(result.isValid && result.compact).toEqual('20070199922');
+  });
+
+  it('validate:20070199951', () => {
+    const result = validate('20070199951');
+
+    expect(result.isValid && result.compact).toEqual('20070199951');
+  });
+
+  it('validate:20070199952', () => {
+    const result = validate('20070199952');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:80000099902', () => {
+    const result = validate('80000099902');
+
+    expect(result.isValid && result.compact).toEqual('80000099902');
+  });
+
+  it('validate:80000099903', () => {
+    const result = validate('80000099903');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:00000199939', () => {
+    const result = validate('00000199939');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:00000199938', () => {
+    const result = validate('00000199938');
+
+    expect(result.isValid && result.compact).toEqual('00000199938');
+  });
+
+  it('validate:99000099913', () => {
+    const result = validate('99000099913');
+
+    expect(result.isValid && result.compact).toEqual('99000099913');
+  });
+
+  it('validate:99000099942', () => {
+    const result = validate('99000099942');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:(unspecified date in current year)', () => {
+    const yy = new Date().getFullYear() % 100;
+    const baseNum = parseInt(`${yy}0000999`, 10);
+    const twoPrefixedBaseNumber = parseInt(`${2}${baseNum}`, 10)
+    const checksum = 97 - (twoPrefixedBaseNumber % 97);
+    const id = `${baseNum}${checksum}`;
+
+    const result = validate(id);
+    expect(result.isValid && result.compact).toEqual(id);
+  });
+
+  it('validate:(unspecified date 100 years ago)', () => {
+    const yy = new Date().getFullYear() % 100;
+    const baseNum = parseInt(`${yy}0000999`, 10);
+    const checksum = 97 - (baseNum % 97);
+    const id = `${baseNum}${checksum}`;
+
+    const result = validate(id);
+    expect(result.isValid && result.compact).toEqual(id);
+  });
+});

--- a/src/be/nn.spec.ts
+++ b/src/be/nn.spec.ts
@@ -110,6 +110,12 @@ describe('be/nn', () => {
     expect(result.isValid && result.compact).toEqual('40000100133');
   });
 
+  it('validate:00000199938', () => {
+    const result = validate('00000199938');
+
+    expect(result.isValid && result.compact).toEqual('00000199938');
+  });
+
   it('validate:40000095579', () => {
     const result = validate('40000095579');
 

--- a/src/be/nn.spec.ts
+++ b/src/be/nn.spec.ts
@@ -104,6 +104,18 @@ describe('be/nn', () => {
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });
 
+  it('validate:40000100133', () => {
+    const result = validate('40000100133');
+
+    expect(result.isValid && result.compact).toEqual('40000100133');
+  });
+
+  it('validate:40000095579', () => {
+    const result = validate('40000095579');
+
+    expect(result.isValid && result.compact).toEqual('40000095579');
+  });
+
   it('validate:(unspecified date in current year)', () => {
     const yy = new Date().getFullYear() % 100;
     const baseNum = parseInt(`${yy}0000999`, 10);

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -111,8 +111,7 @@ function isValidDob(dob: string): boolean {
 
 function getValidPastDates(yymmdd: string): Array<string> {
   const [yy, mm, dd] = toDateArray(yymmdd);
-  return ['19', '20'].
-    map(c => `${c}${yy}`).
+  return getFullYears(yy).
     filter((yyyy) => isValidDateCompactYYYYMMDD(`${yyyy}${mm}${dd}`)).
     map((yyyy) => `${yyyy}-${mm}-${dd}`).
     filter(isInPast);
@@ -129,10 +128,8 @@ function getChecksumBases(number: string): Array<number> {
 
 function getChecksumBasesUnknownDob(dob: string, baseNumber: string): Array<number> {
   const [yy] = toDateArray(dob);
-  const toYear = (prefix: string): number => parseInt(`${prefix}${yy}`, 10);
 
-  return ['19', '20'].
-    map(toYear).
+  return getFullYears(yy).
     filter(isInPast).
     map(year => toChecksumBasis(year, baseNumber));
 }
@@ -155,6 +152,10 @@ function isInPast(date: string | number): boolean {
 function getApproximatelyNow() {
   const ONE_DAY = 1000 * 60 * 60 * 24;
   return new Date(Date.now() + ONE_DAY);
+}
+
+function getFullYears(yy: string | number): Array<number> {
+  return [parseInt(`19${yy}`, 10), parseInt(`20${yy}`, 10)];
 }
 
 function getFirstSix(number: string): string {

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -1,5 +1,27 @@
-// TODO: Add reference to GNU Lesser General Public License
-// From https://github.com/arthurdejong/python-stdnum/blob/master/stdnum/be/nn.py
+// This is adapted from work by Cédric Krier Copyright (C) 2021-2022
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+// 02110-1301 USA
+//
+// NN, NISS (Belgian national number).
+//
+// The national number is a unique identifier of Belgian. The number consists of
+// 11 digits.
+//
+// More information:
+// https://fr.wikipedia.org/wiki/Numéro_de_registre_national
 
 import * as exceptions from '../exceptions';
 import { strings, isValidDateCompactYYYYMMDD } from '../util';

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -112,11 +112,6 @@ function getValidPastDates(yymmdd: string): Array<string> {
     filter(isInPast);
 }
 
-function getApproximatelyNow() {
-  const ONE_DAY = 1000 * 60 * 60 * 24;
-  return new Date(Date.now() + ONE_DAY);
-}
-
 function validStructure(number: string): boolean {
   const firstSix = getFirstSix(number);
   return isValidFirstSix(firstSix);
@@ -134,19 +129,12 @@ function getChecksumBases(number: string): Array<number> {
 
   if (isCompletelyUnknownDob(firstSix)) return [baseNumber];
 
-  if (isDobWithOnlyYearKnown(firstSix)) return getBaseNumbersForOnlyYearKnown(firstSix, baseNumber);
+  if (isDobWithOnlyYearKnown(firstSix)) return getChecksumBasesForYearOnlyKnown(firstSix, baseNumber);
 
   return getChecksumBasesForStandardDate(firstSix, baseNumber);
 }
 
-function getChecksumBasesForStandardDate(firstSix: string, baseNumber: number): Array<number> {
-  const validPastDates = getValidPastDates(firstSix);
-  const extractYearFromDate = (date: string): number => parseInt(date.split('-')[0], 10);
-  const validPastYears = validPastDates.map(extractYearFromDate);
-  return validPastYears.map(year => toChecksumBasis(year, baseNumber));
-}
-
-function getBaseNumbersForOnlyYearKnown(firstSix: string, baseNumber: number): Array<number> {
+function getChecksumBasesForYearOnlyKnown(firstSix: string, baseNumber: number): Array<number> {
   const [yy] = toDateArray(firstSix);
   const toYear = (prefix: string): number => parseInt(`${prefix}${yy}`, 10);
 
@@ -156,13 +144,25 @@ function getBaseNumbersForOnlyYearKnown(firstSix: string, baseNumber: number): A
     map(year => toChecksumBasis(year, baseNumber));
 }
 
-function isInPast(date: string | number): boolean {
-  return new Date(`${date}`) <= getApproximatelyNow();
+function getChecksumBasesForStandardDate(firstSix: string, baseNumber: number): Array<number> {
+  const validPastDates = getValidPastDates(firstSix);
+  const extractYearFromDate = (date: string): number => parseInt(date.split('-')[0], 10);
+  const validPastYears = validPastDates.map(extractYearFromDate);
+  return validPastYears.map(year => toChecksumBasis(year, baseNumber));
 }
 
 function toChecksumBasis(year: number, baseNumber: number): number {
   const twoPrefixedBaseNumber = parseInt(`${2}${baseNumber}`, 10);
   return year < 2000 ? baseNumber : twoPrefixedBaseNumber
+}
+
+function isInPast(date: string | number): boolean {
+  return new Date(`${date}`) <= getApproximatelyNow();
+}
+
+function getApproximatelyNow() {
+  const ONE_DAY = 1000 * 60 * 60 * 24;
+  return new Date(Date.now() + ONE_DAY);
 }
 
 function getFirstSix(number: string): string {

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -1,26 +1,6 @@
-// This is adapted from work by Cédric Krier Copyright (C) 2021-2022
+// The Belgian national number is a unique identifier consisting of 11 digits.
 //
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 2.1 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public
-// License along with this library; if not, write to the Free Software
-// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-// 02110-1301 USA
-//
-// NN, NISS (Belgian national number).
-//
-// The national number is a unique identifier of Belgian. The number consists of
-// 11 digits.
-//
-// More information:
+// For more information:
 // https://fr.wikipedia.org/wiki/Numéro_de_registre_national
 
 import * as exceptions from '../exceptions';

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -83,12 +83,11 @@ function isValidDob(dob: string): boolean {
 
 function getValidPastDates(yymmdd: string): Array<string> {
   const [yy, mm, dd] = toDateArray(yymmdd);
-  const approximatelyNow = getApproximatelyNow();
   return ['19', '20'].
     map(c => `${c}${yy}`).
     filter((yyyy) => isValidDateCompactYYYYMMDD(`${yyyy}${mm}${dd}`)).
     map((yyyy) => `${yyyy}-${mm}-${dd}`).
-    filter((date) => new Date(date) <= approximatelyNow);
+    filter(isInPast);
 }
 
 function getApproximatelyNow() {
@@ -122,19 +121,21 @@ function getChecksumBasesForStandardDate(firstSix: string, baseNumber: number): 
   const validPastDates = getValidPastDates(firstSix);
   const extractYearFromDate = (date: string): number => parseInt(date.split('-')[0], 10);
   const validPastYears = validPastDates.map(extractYearFromDate);
-
   return validPastYears.map(year => toChecksumBasis(year, baseNumber));
 }
 
 function getBaseNumbersForOnlyYearKnown(firstSix: string, baseNumber: number): Array<number> {
   const [yy] = toDateArray(firstSix);
   const toYear = (prefix: string): number => parseInt(`${prefix}${yy}`, 10);
-  return ['19', '20'].map(toYear).filter(yearHasStarted).map(year => toChecksumBasis(year, baseNumber));
+
+  return ['19', '20'].
+    map(toYear).
+    filter(isInPast).
+    map(year => toChecksumBasis(year, baseNumber));
 }
 
-function yearHasStarted(year: number): boolean {
-  const startOfYear = new Date(`${year}`);
-  return startOfYear <= getApproximatelyNow();
+function isInPast(date: string | number): boolean {
+  return new Date(`${date}`) <= getApproximatelyNow();
 }
 
 function toChecksumBasis(year: number, baseNumber: number): number {

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -96,7 +96,7 @@ function isCompletelyUnknownDob(dob: string): boolean {
 
 function isDobWithOnlyYearKnown(dob: string): boolean {
   const [yy, mm, dd] = toDateArray(dob);
-  return (strings.isdigits(yy) && mm === '00' && dd === '00');
+  return (strings.isdigits(yy) && mm === '00' && strings.isdigits(dd));
 }
 
 function isValidDob(dob: string): boolean {

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -85,6 +85,17 @@ export const {
   compact,
 } = impl;
 
+function validStructure(number: string): boolean {
+  const firstSix = getFirstSix(number);
+  return isValidFirstSix(firstSix);
+}
+
+function validChecksum(number: string): boolean {
+  const checksumBases = getChecksumBases(number);
+  const [, checksum] = getBaseNumberAndChecksum(number);
+  return checksumBases.some(csb => csb % 97 + checksum === 97);
+}
+
 function isValidFirstSix(firstSix: string): boolean {
   if (isCompletelyUnknownDob(firstSix) || isDobWithOnlyYearKnown(firstSix)) return true;
   return isValidDob(firstSix);
@@ -110,17 +121,6 @@ function getValidPastDates(yymmdd: string): Array<string> {
     filter((yyyy) => isValidDateCompactYYYYMMDD(`${yyyy}${mm}${dd}`)).
     map((yyyy) => `${yyyy}-${mm}-${dd}`).
     filter(isInPast);
-}
-
-function validStructure(number: string): boolean {
-  const firstSix = getFirstSix(number);
-  return isValidFirstSix(firstSix);
-}
-
-function validChecksum(number: string): boolean {
-  const checksumBases = getChecksumBases(number);
-  const [, checksum] = getBaseNumberAndChecksum(number);
-  return checksumBases.some(csb => csb % 97 + checksum === 97);
 }
 
 function getChecksumBases(number: string): Array<number> {

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -1,0 +1,155 @@
+// TODO: Add reference to GNU Lesser General Public License
+// From https://github.com/arthurdejong/python-stdnum/blob/master/stdnum/be/nn.py
+
+import * as exceptions from '../exceptions';
+import { strings, isValidDateCompactYYYYMMDD } from '../util';
+import { Validator, ValidateReturn } from '../types';
+
+function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
+  return strings.cleanUnicode(input, ' -.');
+}
+
+const impl: Validator = {
+  name: 'Belgian National Number',
+  localName: 'Numéro National',
+  abbreviation: 'NN, NISS',
+  compact(input: string): string {
+    const [value, err] = clean(input);
+
+    if (err) {
+      throw err;
+    }
+
+    return value;
+  },
+  format(input: string): string {
+    const [value] = clean(input);
+    return value;
+  },
+  validate(input: string): ValidateReturn {
+    const number = compact(input);
+
+    if (!strings.isdigits(number) || parseInt(number, 10) <= 0) {
+      return { isValid: false, error: new exceptions.InvalidFormat() }
+    }
+
+    if (number.length !== 11) {
+      return { isValid: false, error: new exceptions.InvalidLength() }
+    }
+
+    if (!validStructure(number)) {
+      return { isValid: false, error: new exceptions.InvalidFormat() }
+    }
+
+    if (!validChecksum(number)) {
+      return { isValid: false, error: new exceptions.InvalidChecksum() }
+    }
+
+    return {
+      isValid: true,
+      compact: number,
+      isIndividual: true,
+      isCompany: false,
+    }
+  }
+}
+
+export const {
+  name,
+  localName,
+  abbreviation,
+  validate,
+  format,
+  compact,
+} = impl;
+
+function isValidFirstSix(firstSix: string): boolean {
+  if (isCompletelyUnknownDob(firstSix) || isDobWithOnlyYearKnown(firstSix)) return true;
+  return isValidDob(firstSix);
+}
+
+function isCompletelyUnknownDob(dob: string): boolean {
+  return (dob === '000001');
+}
+
+function isDobWithOnlyYearKnown(dob: string): boolean {
+  const [yy, mm, dd] = toDateArray(dob);
+  return (strings.isdigits(yy) && mm === '00' && dd === '00');
+}
+
+function isValidDob(dob: string): boolean {
+  return Boolean(getValidPastDates(dob).length);
+}
+
+function getValidPastDates(yymmdd: string): Array<string> {
+  const [yy, mm, dd] = toDateArray(yymmdd);
+  const approximatelyNow = getApproximatelyNow();
+  return ['19', '20'].
+    map(c => `${c}${yy}`).
+    filter((yyyy) => isValidDateCompactYYYYMMDD(`${yyyy}${mm}${dd}`)).
+    map((yyyy) => `${yyyy}-${mm}-${dd}`).
+    filter((date) => new Date(date) <= approximatelyNow);
+}
+
+function getApproximatelyNow() {
+  const ONE_DAY = 1000 * 60 * 60 * 24;
+  return new Date(Date.now() + ONE_DAY);
+}
+
+function validStructure(number: string): boolean {
+  const firstSix = getFirstSix(number);
+  return isValidFirstSix(firstSix);
+}
+
+function validChecksum(number: string): boolean {
+  const checksumBases = getChecksumBases(number);
+  const [, checksum] = getBaseNumberAndChecksum(number);
+  return checksumBases.some(csb => csb % 97 + checksum === 97);
+}
+
+function getChecksumBases(number: string): Array<number> {
+  const firstSix = getFirstSix(number);
+  const [baseNumber] = getBaseNumberAndChecksum(number);
+
+  if (isCompletelyUnknownDob(firstSix)) return [baseNumber];
+
+  if (isDobWithOnlyYearKnown(firstSix)) return getBaseNumbersForOnlyYearKnown(firstSix, baseNumber);
+
+  return getChecksumBasesForStandardDate(firstSix, baseNumber);
+}
+
+function getChecksumBasesForStandardDate(firstSix: string, baseNumber: number): Array<number> {
+  const validPastDates = getValidPastDates(firstSix);
+  const extractYearFromDate = (date: string): number => parseInt(date.split('-')[0], 10);
+  const validPastYears = validPastDates.map(extractYearFromDate);
+
+  return validPastYears.map(year => toChecksumBasis(year, baseNumber));
+}
+
+function getBaseNumbersForOnlyYearKnown(firstSix: string, baseNumber: number): Array<number> {
+  const [yy] = toDateArray(firstSix);
+  const toYear = (prefix: string): number => parseInt(`${prefix}${yy}`, 10);
+  return ['19', '20'].map(toYear).filter(yearHasStarted).map(year => toChecksumBasis(year, baseNumber));
+}
+
+function yearHasStarted(year: number): boolean {
+  const startOfYear = new Date(`${year}`);
+  return startOfYear <= getApproximatelyNow();
+}
+
+function toChecksumBasis(year: number, baseNumber: number): number {
+  const twoPrefixedBaseNumber = parseInt(`${2}${baseNumber}`, 10);
+  return year < 2000 ? baseNumber : twoPrefixedBaseNumber
+}
+
+function getFirstSix(number: string): string {
+  return strings.splitAt(number, 6)[0];
+}
+
+function getBaseNumberAndChecksum(number: string): Array<number> {
+  return strings.splitAt(number, 9).map(n => parseInt(n, 10));
+}
+
+function toDateArray(number: string): Array<string> {
+  return strings.splitAt(number, 2, 4);
+}


### PR DESCRIPTION
This work adds the Belgian National Number, based on [this](https://github.com/arthurdejong/python-stdnum/blob/master/stdnum/be/nn.py) work in the Python library with some additions.

This code works for all examples given in [the Wikipedia article](https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_registre_national).

This work accounts for ambiguous numbers that could go with someone very young or someone over 100. For example, an identifier that starts with '19' will be validated for both someone born in 1919 and someone born in 2019 and considered valid if the validation passes for either.