### PR TITLE
fix(be): properly include belgium nn

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All country validators are in the "namespace" of the ISO country code.
 | Australia              | AU   | TFN             | Tax/Person/Company | Australian Tax File Number                                                          |
 | Bosnia and Herzegovina | BA   | JMBG            | Person             | Unique Master Citizen Number                                                        |
 | Belize                 | BZ   | TIN             | Person/Company     | Brazilian Tax ID ()                                                                 |
+| Belgium                | BE   | NN              | Person             | Belgian National Number (Numéro National)
 | Belgium                | BE   | VAT             | Company            | Belgian Enterprise Number                                                           |
 | Bulgaria               | BG   | EGN             | Person             | ЕГН, Единен граждански номер, Bulgarian personal identity codes                     |
 | Bulgaria               | BG   | PNF             | Person             | PNF (ЛНЧ, Личен номер на чужденец, Bulgarian number of a foreigner).                |

--- a/src/be/index.ts
+++ b/src/be/index.ts
@@ -1,1 +1,2 @@
+export * as nn from './nn';
 export * as vat from './vat';

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -1,7 +1,11 @@
-// The Belgian national number is a unique identifier consisting of 11 digits.
-//
-// For more information:
-// https://fr.wikipedia.org/wiki/Numéro_de_registre_national
+/**
+* The Belgian national number is a unique identifier consisting of 11 digits.
+*
+* Source
+*  https://fr.wikipedia.org/wiki/Numéro_de_registre_national
+*
+* PERSON
+*/
 
 import * as exceptions from '../exceptions';
 import { strings, isValidDateCompactYYYYMMDD } from '../util';

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,7 @@ export const personValidators: Record<string, Validator[]> = {
   AU: [AU.tfn],
   AZ: [AZ.pin, AZ.tin],
   BA: [BA.jmbg],
+  BE: [BE.nn],
   BG: [BG.egn, BG.pnf, BG.vat],
   BR: [BR.cpf],
   BY: [BY.unp],


### PR DESCRIPTION
This will properly include Belgian NN in `stdnum` and `personIdentifiers`