### PR TITLE
feat(be): add bis and insz

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All country validators are in the "namespace" of the ISO country code.
 | Bosnia and Herzegovina | BA   | JMBG            | Person             | Unique Master Citizen Number                                                        |
 | Belize                 | BZ   | TIN             | Person/Company     | Brazilian Tax ID ()                                                                 |
 | Belgium                | BE   | BIS             | Person             | Belgian Number for Foreigners                                                       |
-| Belgium                | BE   | INSZ            | Person             | Belgian Social Security Identification Number (Identificatienummer van de Sociale Zekerheid) |
+| Belgium                | BE   | INSZ, NISS      | Person             | Belgian Social Security Identification Number (Identificatienummer van de Sociale Zekerheid, Numéro d'Identification Sécurité Sociale) |
 | Belgium                | BE   | NN              | Person             | Belgian National Number (Numéro National)                                           |
 | Belgium                | BE   | VAT             | Company            | Belgian Enterprise Number                                                           |
 | Bulgaria               | BG   | EGN             | Person             | ЕГН, Единен граждански номер, Bulgarian personal identity codes                     |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ All country validators are in the "namespace" of the ISO country code.
 | Australia              | AU   | TFN             | Tax/Person/Company | Australian Tax File Number                                                          |
 | Bosnia and Herzegovina | BA   | JMBG            | Person             | Unique Master Citizen Number                                                        |
 | Belize                 | BZ   | TIN             | Person/Company     | Brazilian Tax ID ()                                                                 |
-| Belgium                | BE   | NN              | Person             | Belgian National Number (Numéro National)
+| Belgium                | BE   | BIS             | Person             | Belgian Number for Foreigners                                                       |
+| Belgium                | BE   | NN              | Person             | Belgian National Number (Numéro National)                                           |
 | Belgium                | BE   | VAT             | Company            | Belgian Enterprise Number                                                           |
 | Bulgaria               | BG   | EGN             | Person             | ЕГН, Единен граждански номер, Bulgarian personal identity codes                     |
 | Bulgaria               | BG   | PNF             | Person             | PNF (ЛНЧ, Личен номер на чужденец, Bulgarian number of a foreigner).                |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ All country validators are in the "namespace" of the ISO country code.
 | Bosnia and Herzegovina | BA   | JMBG            | Person             | Unique Master Citizen Number                                                        |
 | Belize                 | BZ   | TIN             | Person/Company     | Brazilian Tax ID ()                                                                 |
 | Belgium                | BE   | BIS             | Person             | Belgian Number for Foreigners                                                       |
+| Belgium                | BE   | INSZ            | Person             | Belgian Social Security Identification Number                                       |
 | Belgium                | BE   | NN              | Person             | Belgian National Number (Numéro National)                                           |
 | Belgium                | BE   | VAT             | Company            | Belgian Enterprise Number                                                           |
 | Bulgaria               | BG   | EGN             | Person             | ЕГН, Единен граждански номер, Bulgarian personal identity codes                     |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All country validators are in the "namespace" of the ISO country code.
 | Bosnia and Herzegovina | BA   | JMBG            | Person             | Unique Master Citizen Number                                                        |
 | Belize                 | BZ   | TIN             | Person/Company     | Brazilian Tax ID ()                                                                 |
 | Belgium                | BE   | BIS             | Person             | Belgian Number for Foreigners                                                       |
-| Belgium                | BE   | INSZ            | Person             | Belgian Social Security Identification Number                                       |
+| Belgium                | BE   | INSZ            | Person             | Belgian Social Security Identification Number (Identificatienummer van de Sociale Zekerheid) |
 | Belgium                | BE   | NN              | Person             | Belgian National Number (Numéro National)                                           |
 | Belgium                | BE   | VAT             | Company            | Belgian Enterprise Number                                                           |
 | Bulgaria               | BG   | EGN             | Person             | ЕГН, Единен граждански номер, Bulgarian personal identity codes                     |

--- a/src/be/bis.spec.ts
+++ b/src/be/bis.spec.ts
@@ -1,0 +1,186 @@
+import { validate, format } from './bis';
+import { InvalidLength, InvalidChecksum, InvalidFormat } from '../exceptions';
+
+describe('be/bis', () => {
+  it('format:88 22 29-999.70', () => {
+    const result = format('88 02 29-999.70')
+
+    expect(result).toEqual('88022999970');
+  });
+
+  it('validate:1', () => {
+    const result = validate('1');
+
+    expect(result.error).toBeInstanceOf(InvalidLength);
+  });
+
+  it('validate:88022999990', () => {
+    // A number that validates for NN, should be invalid
+    const result = validate('88022999990');
+
+    expect(result.error).toBeInstanceOf(InvalidFormat);
+  });
+
+  it('validate:88222999936', () => {
+    // A number with an offset of 20, should be valid assuming 19xx
+    const result = validate('88222999936');
+
+    expect(result.isValid && result.compact).toEqual('88222999936');
+  });
+
+  it('validate:08222999934', () => {
+    // A number with an offset of 20, should be valid assuming 20xx
+    const result = validate('08222999934');
+
+    expect(result.isValid && result.compact).toEqual('08222999934');
+  });
+
+  it('validate:88422999979', () => {
+    // A number with an offset of 40, should be valid assuming 19xx
+    const result = validate('88422999979');
+
+    expect(result.isValid && result.compact).toEqual('88422999979');
+  });
+
+  it('validate:08422999977', () => {
+    // A number with an offset of 40, should be valid assuming 20xx
+    const result = validate('08422999977');
+
+    expect(result.isValid && result.compact).toEqual('08422999977');
+  });
+
+  it('validate:96331699989', () => {
+    // A number with an offset of 20, should be invalid due to invalid month
+    const result = validate('96331699989');
+
+    expect(result.error).toBeInstanceOf(InvalidFormat);
+  });
+
+  it('validate:08222999935', () => {
+    // A number with an offset of 20, should be invalid due to invalid checksum
+    const result = validate('08222999935');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  })
+
+  it('validate:96531699935', () => {
+    // A number with an offset of 40, should be invalid due to invalid month
+    const result = validate('96531699935');
+
+    expect(result.error).toBeInstanceOf(InvalidFormat);
+  });
+
+  it('validate:08451799971', () => {
+    // A number with an offset of 40, should be invalid due to invalid checksum
+    const result = validate('08451799971');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:92612099915', () => {
+    // A number with an offset of 60, should be invalid due to invalid month
+    const result = validate('92612099915');
+
+    expect(result.error).toBeInstanceOf(InvalidFormat);
+  });
+
+  it('validate:99200199926', () => {
+    // A number with an unknown dob offset by 20, should be valid assuming 19xx
+    const result = validate('99200199926');
+
+    expect(result.isValid && result.compact).toEqual('99200199926');
+  });
+
+  it('validate:01200199934', () => {
+    // A number with an unknown dob offset by 20, should be valid assuming 20xx
+    const result = validate('01200199934');
+
+    console.log(JSON.stringify(result, null, 2));
+
+    expect(result.isValid && result.compact).toEqual('01200199934');
+  });
+
+  it('validate:01200199935', () => {
+    // A number with an unknown dob offset by 20, should be invalid by checksum
+    const result = validate('01200199935');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:99400199969', () => {
+    // A number with an unknown dob offset by 40, should be valid assuming 19xx
+    const result = validate('99400199969');
+
+    expect(result.isValid && result.compact).toEqual('99400199969');
+  });
+
+  it('validate:01451599980', () => {
+    // A number with an unknown dob offset by 40, should be valid assuming 20xx
+    const result = validate('01451599980');
+
+    expect(result.isValid && result.compact).toEqual('01451599980');
+  });
+
+  it('validate:01400199977', () => {
+    // A number with an unknown dob offset by 40, should be valid assuming 20xx
+    const result = validate('01400199977');
+
+    expect(result.isValid && result.compact).toEqual('01400199977');
+  });
+
+  it('validate:01400199981', () => {
+    // A number with an unknown dob offset by 40, should be invalid by checksum
+    const result = validate('01400199981');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum)
+  });
+
+  it('validate:00290199976', () => {
+    // A number that starts with 00 can be valid
+    const result = validate('00290199976');
+
+    expect(result.isValid && result.compact).toEqual('00290199976');
+  });
+
+  it('validate:(unspecified date in current year, offset of 20)', () => {
+    const yy = new Date().getFullYear() % 100;
+    const baseNum = parseInt(`${yy}2000999`, 10);
+    const twoPrefixedBaseNumber = parseInt(`${2}${baseNum}`, 10);
+    const checksum = 97 - (twoPrefixedBaseNumber % 97);
+    const id = `${baseNum}${checksum}`;
+
+    const result = validate(id);
+    expect(result.isValid && result.compact).toEqual(id);
+  });
+
+  it('validate:(unspecified date in current year, offset of 40)', () => {
+    const yy = new Date().getFullYear() % 100;
+    const baseNum = parseInt(`${yy}4000999`, 10);
+    const twoPrefixedBaseNumber = parseInt(`${2}${baseNum}`, 10);
+    const checksum = 97 - (twoPrefixedBaseNumber % 97);
+    const id = `${baseNum}${checksum}`;
+
+    const result = validate(id);
+    expect(result.isValid && result.compact).toEqual(id);
+  });
+
+  it('validate:(unspecified date 100 years ago, offset of 20)', () => {
+    const yy = new Date().getFullYear() % 100;
+    const baseNum = parseInt(`${yy}2000999`, 10);
+    const checksum = 97 - (baseNum % 97);
+    const id = `${baseNum}${checksum}`;
+
+    const result = validate(id);
+    expect(result.isValid && result.compact).toEqual(id);
+  });
+
+  it('validate:(unspecified date 100 years ago, offset of 40)', () => {
+    const yy = new Date().getFullYear() % 100;
+    const baseNum = parseInt(`${yy}4000999`, 10);
+    const checksum = 97 - (baseNum % 97);
+    const id = `${baseNum}${checksum}`;
+
+    const result = validate(id);
+    expect(result.isValid && result.compact).toEqual(id);
+  });
+});

--- a/src/be/bis.spec.ts
+++ b/src/be/bis.spec.ts
@@ -95,8 +95,6 @@ describe('be/bis', () => {
     // A number with an unknown dob offset by 20, should be valid assuming 20xx
     const result = validate('01200199934');
 
-    console.log(JSON.stringify(result, null, 2));
-
     expect(result.isValid && result.compact).toEqual('01200199934');
   });
 

--- a/src/be/bis.ts
+++ b/src/be/bis.ts
@@ -1,8 +1,12 @@
 /**
-* The Belgian national number is a unique identifier consisting of 11 digits.
+* The BIS (Belgian Number for Foreigners) is an identifier for individuals such
+* as cross-border workers who do not have a Belgian National Number. It has the
+* same format as the Belgian National Number, but the month digits are increased
+* by 40 if the sex of the person was known when the number was assigned and by
+* 20 if not.
 *
 * Source
-*  https://fr.wikipedia.org/wiki/Numéro_de_registre_national
+*  https://fr.wikipedia.org/wiki/Numéro_de_registre_national (Numéro de sécurité sociale)
 *
 * PERSON
 */

--- a/src/be/bis.ts
+++ b/src/be/bis.ts
@@ -29,9 +29,9 @@ function toDob(firstSix: string): string {
 }
 
 const impl: Validator = {
-  name: 'Belgian National Number',
-  localName: 'Numéro National',
-  abbreviation: 'NN, NISS',
+  name: 'Belgian Number for Foreigners',
+  localName: 'BIS',
+  abbreviation: 'BIS',
   compact(input: string): string {
     const [value, err] = clean(input);
 

--- a/src/be/bis.ts
+++ b/src/be/bis.ts
@@ -30,7 +30,7 @@ function toDob(firstSix: string): string {
 
 const impl: Validator = {
   name: 'Belgian Number for Foreigners',
-  localName: 'BIS',
+  localName: 'Numéro BIS',
   abbreviation: 'BIS',
   compact(input: string): string {
     const [value, err] = clean(input);

--- a/src/be/index.ts
+++ b/src/be/index.ts
@@ -1,3 +1,4 @@
 export * as bis from './bis';
+export * as insz from './insz';
 export * as nn from './nn';
 export * as vat from './vat';

--- a/src/be/index.ts
+++ b/src/be/index.ts
@@ -1,2 +1,3 @@
+export * as bis from './bis';
 export * as nn from './nn';
 export * as vat from './vat';

--- a/src/be/insz.spec.ts
+++ b/src/be/insz.spec.ts
@@ -1,0 +1,51 @@
+import { validate, format } from './insz';
+import { InvalidLength, InvalidChecksum, InvalidFormat } from '../exceptions';
+
+describe('be/insz', () => {
+  it('format:88 02 29-999.90', () => {
+    const result = format('88 02 29-999.90');
+
+    expect(result).toEqual('88022999990');
+  });
+
+  it('validate:1', () => {
+    const result = validate('1');
+
+    expect(result.error).toBeInstanceOf(InvalidLength);
+  });
+
+  it('validate:88022999990', () => {
+    // Valid only for NN, returns true
+    const result = validate('88022999990');
+
+    expect(result.isValid && result.compact).toEqual('88022999990');
+  });
+
+  it('validate:88222999936', () => {
+    // Valid only for BIS, returns true
+    const result = validate('88222999936');
+
+    expect(result.isValid && result.compact).toEqual('88222999936');
+  });
+
+  it('validate:88150199951', () => {
+    // Invalid Format for both
+    const result = validate('88150199951');
+
+    expect(result.error).toBeInstanceOf(InvalidFormat);
+  });
+
+  it('validate:08222999935', () => {
+    // Invalid format for NN (month + 20), Invalid checksum for BIS
+    const result = validate('08222999935');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:20070199952', () => {
+    // Invalid checksum for NN, Invalid format for BIS
+    const result = validate('20070199952');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+});

--- a/src/be/insz.ts
+++ b/src/be/insz.ts
@@ -21,7 +21,7 @@ function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
 const impl: Validator = {
   name: 'Belgian Social Security Identification Number',
   localName: 'Identificatienummer van de Sociale Zekerheid',
-  abbreviation: 'INSZ',
+  abbreviation: 'INSZ, NISS',
   compact(input: string): string {
     const [value, err] = clean(input);
 

--- a/src/be/insz.ts
+++ b/src/be/insz.ts
@@ -33,8 +33,8 @@ function getValidation(number: string): ValidateReturn {
 }
 
 const impl: Validator = {
-  name: '',
-  localName: '',
+  name: 'Belgian Social Security Identification Number',
+  localName: 'Identificatienummer van de Sociale Zekerheid',
   abbreviation: 'INSZ',
   compact(input: string): string {
     const [value, err] = clean(input);

--- a/src/be/insz.ts
+++ b/src/be/insz.ts
@@ -1,0 +1,68 @@
+/**
+* The Belgian Social Security Identification Number is an 11 digit number.
+* It can be either a National Register Number (NN, NISS) or BIS.
+*
+* Sources
+*  https://fr.wikipedia.org/wiki/Numéro_de_registre_national
+*  https://www2.deloitte.com/content/dam/Deloitte/be/Documents/tax/TaxAlerts/IndividualTaxAlerts/Social%20Security%20alert%20-%20BelgianIDpro%20-%2026%20Nov%202020.pdf
+*
+* PERSON
+*/
+
+import * as exceptions from '../exceptions';
+import { strings } from '../util';
+import { validate as nnValidate } from './nn';
+import { validate as bisValidate } from './bis';
+import { Validator, ValidateReturn } from '../types';
+
+function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
+  return strings.cleanUnicode(input, ' -.');
+}
+
+function getValidation(number: string): ValidateReturn {
+  const results = [nnValidate(number), bisValidate(number)];
+  const validResult = results.find(r => r.isValid);
+  if (validResult) return validResult;
+
+  // The only case with two different error types is an invalid checksum and an
+  // invalid format. The identifier with the checksum error had correct
+  // formatting, so invalid checksum seems like the more descriptive error.
+
+  const checksumErrorResult = results.find(r => r.error && r.error.name === 'InvalidChecksum');
+  return checksumErrorResult || results[0];
+}
+
+const impl: Validator = {
+  name: '',
+  localName: '',
+  abbreviation: 'INSZ',
+  compact(input: string): string {
+    const [value, err] = clean(input);
+
+    if (err) {
+      throw err;
+    }
+
+    return value;
+  },
+  format(input: string): string {
+    const [value] = clean(input);
+    return value;
+  },
+  validate(input: string): ValidateReturn {
+    const number = impl.compact(input);
+
+    if (!strings.isdigits(number) || parseInt(number, 10) <= 0) {
+      return { isValid: false, error: new exceptions.InvalidFormat() };
+    }
+
+    if (number.length !== 11) {
+      return { isValid: false, error: new exceptions.InvalidLength() };
+    }
+
+    return getValidation(number);
+  },
+};
+
+export const { name, localName, abbreviation, validate, format, compact } =
+  impl;

--- a/src/be/nn.ts
+++ b/src/be/nn.ts
@@ -19,7 +19,7 @@ function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
 const impl: Validator = {
   name: 'Belgian National Number',
   localName: 'Numéro National',
-  abbreviation: 'NN, NISS',
+  abbreviation: 'NN, RN',
   compact(input: string): string {
     const [value, err] = clean(input);
 

--- a/src/be/personIdentifierHelpers.spec.ts
+++ b/src/be/personIdentifierHelpers.spec.ts
@@ -1,0 +1,237 @@
+import { validStructure, validChecksum, toDateArray } from './personIdentifierHelpers';
+
+describe('personIdentifierHelpers', () => {
+  const toDob = (string: string): string => {
+    const [y, m, d] = toDateArray(string).map(s => parseInt(s, 10));
+    return [y, m - 1, d].map(n => `${n}`.padStart(2, '0')).join('');
+  };
+
+  describe('validStructure', () => {
+    describe('default dob conversion', () => {
+      it('returns true for a valid 20th century date', () => {
+        expect(validStructure('99012599999')).toEqual(true);
+      });
+
+      it('returns true for a potential 21st century date', () => {
+        expect(validStructure('01012599999')).toEqual(true);
+      });
+
+      it('returns true for an unknown date of birth', () => {
+        expect(validStructure('01009999999')).toEqual(true);
+      });
+
+      it('returns false for a string that is neither an unknown date of birth or a valid date of birth', () => {
+        expect(validStructure('99999999999')).toEqual(false);
+      });
+    });
+
+    describe('specified dob conversion', () => {
+      it('returns true for a valid 20th century date', () => {
+        expect(validStructure('991331999999', toDob)).toEqual(true);
+      });
+
+      it('returns true for a potential 21st century date', () => {
+        expect(validStructure('011331999999', toDob)).toEqual(true);
+      });
+
+      it('returns true for an unknown date of birth', () => {
+        expect(validStructure('990199999999', toDob)).toEqual(true);
+      });
+
+      it('returns false for a string that is neither an unknown date of birth or a valid date of birth', () => {
+        expect(validStructure('99999999999', toDob)).toEqual(false);
+      });
+    });
+  });
+  describe('validChecksum', () => {
+    const range = Array.from({ length: 100 }, (_, n) => n);
+
+    describe('default dob conversion', () => {
+      describe('a date of birth valid in the 20th century only', () => {
+        const baseString = '990430999';
+        const checksum = 14;
+
+        it('returns true when the checksum is valid', () => {
+          const string = `${baseString}${checksum}`;
+          expect(validChecksum(string)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const toCheck = range.filter(x => x !== checksum);
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string)).toEqual(false);
+          });
+        });
+      });
+
+      describe('a date of birth valid in the 21st century only', () => {
+        const baseString = '000229999'; // 1900 was not a leap year
+        const checksum = 17;
+
+        it('returns true when the checksum is valid', () => {
+          const string = `${baseString}${checksum}`;
+          expect(validChecksum(string)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const toCheck = range.filter(x => x !== checksum);
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string)).toEqual(false);
+          });
+        });
+      });
+
+      describe('a date of birth valid in either the 20th or 21st century', () => {
+        const baseString = '100430999';
+        const twentiethCenturyChecksum = 85;
+        const twentyfirstCenturyChecksum = 17;
+
+        it('returns true when the checksum is valid for the 20th century', () => {
+          const string = `${baseString}${twentiethCenturyChecksum}`;
+          expect(validChecksum(string)).toEqual(true);
+        });
+
+        it('returns true when the checksum is valid for the 21th century', () => {
+          const string = `${baseString}${twentyfirstCenturyChecksum}`;
+          expect(validChecksum(string)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const excludedChecksums = [twentiethCenturyChecksum, twentyfirstCenturyChecksum];
+          const toCheck = range.filter(x => !excludedChecksums.includes(x));
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string)).toEqual(false);
+          });
+        });
+      });
+
+      describe('an unknown date of birth', () => {
+        const baseString = '100001999';
+        const twentiethCenturyChecksum = 54;
+        const twentyfirstCenturyChecksum = 83;
+
+        it('returns true when the checksum is valid for the 20th century', () => {
+          const string = `${baseString}${twentiethCenturyChecksum}`;
+          expect(validChecksum(string)).toEqual(true);
+        });
+
+        it('returns true when the checksum is valid for the 21th century', () => {
+          const string = `${baseString}${twentyfirstCenturyChecksum}`;
+          expect(validChecksum(string)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const excludedChecksums = [twentiethCenturyChecksum, twentyfirstCenturyChecksum];
+          const toCheck = range.filter(x => !excludedChecksums.includes(x));
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string)).toEqual(false);
+          });
+        });
+      });
+    });
+
+    describe('specified dob conversion', () => {
+      describe('a date of birth valid in the 20th century only', () => {
+        const baseString = '990631999';
+        const checksum = 95;
+
+        it('returns true when the checksum is valid', () => {
+          const string = `${baseString}${checksum}`;
+          expect(validChecksum(string, toDob)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const toCheck = range.filter(x => x !== checksum);
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string, toDob)).toEqual(false);
+          });
+        });
+      });
+
+      describe('a date of birth valid in the 21st century only', () => {
+        const baseString = '000329999'; // 1900 was not a leap year
+        const checksum = 24;
+
+        it('returns true when the checksum is valid', () => {
+          const string = `${baseString}${checksum}`;
+          expect(validChecksum(string, toDob)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const toCheck = range.filter(x => x !== checksum);
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string, toDob)).toEqual(false);
+          });
+        });
+      });
+
+      describe('a date of birth valid in either the 20th or 21st century', () => {
+        const baseString = '100430999';
+        const twentiethCenturyChecksum = 85;
+        const twentyfirstCenturyChecksum = 17;
+
+        it('returns true when the checksum is valid for the 20th century', () => {
+          const string = `${baseString}${twentiethCenturyChecksum}`;
+          expect(validChecksum(string, toDob)).toEqual(true);
+        });
+
+        it('returns true when the checksum is valid for the 21th century', () => {
+          const string = `${baseString}${twentyfirstCenturyChecksum}`;
+          expect(validChecksum(string, toDob)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const excludedChecksums = [twentiethCenturyChecksum, twentyfirstCenturyChecksum];
+          const toCheck = range.filter(x => !excludedChecksums.includes(x));
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string, toDob)).toEqual(false);
+          });
+        });
+      });
+
+      describe('an unknown date of birth', () => {
+        const baseString = '100101999';
+        const twentiethCenturyChecksum = 61;
+        const twentyfirstCenturyChecksum = 90;
+
+        it('returns true when the checksum is valid for the 20th century', () => {
+          const string = `${baseString}${twentiethCenturyChecksum}`;
+          expect(validChecksum(string, toDob)).toEqual(true);
+        });
+
+        it('returns true when the checksum is valid for the 21th century', () => {
+          const string = `${baseString}${twentyfirstCenturyChecksum}`;
+          expect(validChecksum(string, toDob)).toEqual(true);
+        });
+
+        it('returns false when the checksum is invalid', () => {
+          const excludedChecksums = [twentiethCenturyChecksum, twentyfirstCenturyChecksum];
+          const toCheck = range.filter(x => !excludedChecksums.includes(x));
+          toCheck.forEach((cs) => {
+            const string = `${baseString}${cs}`;
+            expect(validChecksum(string, toDob)).toEqual(false);
+          });
+        });
+      });
+    });
+  });
+
+  describe('toDateArray', () => {
+    it('works with a string of length 6', () => {
+      const string = '013150';
+      expect(toDateArray(string)).toEqual(['01', '31', '50']);
+    });
+
+    it('works with a string of length greater than 6', () => {
+      const string = '013150999';
+      expect(toDateArray(string)).toEqual(['01', '31', '50']);
+    });
+  });
+});

--- a/src/be/personIdentifierHelpers.ts
+++ b/src/be/personIdentifierHelpers.ts
@@ -1,0 +1,111 @@
+import { strings, isValidDateCompactYYYYMMDD } from '../util';
+
+function getApproximatelyNow() {
+  const ONE_DAY = 1000 * 60 * 60 * 24;
+  return new Date(Date.now() + ONE_DAY);
+}
+
+function isInPast(date: string | number): boolean {
+  return new Date(`${date}`) <= getApproximatelyNow();
+}
+
+function getFullYears(yy: string | number): Array<number> {
+  return [parseInt(`19${yy}`, 10), parseInt(`20${yy}`, 10)];
+}
+
+function getFirstSix(number: string): string {
+  return strings.splitAt(number, 6)[0];
+}
+
+function getBaseNumber(number: string): string {
+  return strings.splitAt(number, 9)[0];
+}
+
+function getChecksum(number: string): number {
+  const checksumString = strings.splitAt(number, 9)[1];
+  return parseInt(checksumString, 10);
+}
+
+export function toDateArray(number: string): Array<string> {
+  return strings.splitAt(number, 2, 4, 6).slice(0, 3);
+}
+
+function getValidPastDates(yymmdd: string): Array<string> {
+  const [yy, mm, dd] = toDateArray(yymmdd);
+  return getFullYears(yy)
+    .filter(yyyy => isValidDateCompactYYYYMMDD(`${yyyy}${mm}${dd}`))
+    .map(yyyy => `${yyyy}-${mm}-${dd}`)
+    .filter(isInPast);
+}
+
+function isUnknownDob(dob: string): boolean {
+  const [yy, mm, dd] = toDateArray(dob);
+  return strings.isdigits(yy) && mm === '00' && strings.isdigits(dd);
+}
+
+function toChecksumBasis(year: number, baseNumber: string): number {
+  return parseInt(year < 2000 ? baseNumber : `${2}${baseNumber}`, 10);
+}
+
+function isValidDob(dob: string): boolean {
+  return Boolean(getValidPastDates(dob).length);
+}
+
+function defaultToDob(origFirstSix: string): string {
+  return origFirstSix;
+}
+
+function isValidFirstSix(firstSix: string, toDob: typeof defaultToDob): boolean {
+  const dob = toDob(firstSix);
+  return isUnknownDob(dob) || isValidDob(dob);
+}
+
+export function validStructure(number: string, toDob: typeof defaultToDob = defaultToDob): boolean {
+  const firstSix = getFirstSix(number);
+  return isValidFirstSix(firstSix, toDob);
+}
+
+function getChecksumBasesUnknownDob(
+  baseNumber: string,
+): Array<number> {
+  const firstSix = getFirstSix(baseNumber);
+  const [yy] = toDateArray(firstSix);
+
+  return getFullYears(yy)
+    .filter(isInPast)
+    .map(year => toChecksumBasis(year, baseNumber));
+}
+
+function getChecksumBasesForStandardDob(
+  baseNumber: string,
+  toDob: typeof defaultToDob,
+): Array<number> {
+  const firstSix = getFirstSix(baseNumber);
+  const dob = toDob(firstSix);
+  const validPastDates = getValidPastDates(dob);
+  const extractYearFromDate = (date: string): number =>
+    parseInt(date.split('-')[0], 10);
+  const validPastYears = validPastDates.map(extractYearFromDate);
+  return validPastYears.map(year => toChecksumBasis(year, baseNumber));
+}
+
+function getChecksumBases(number: string, toDob: typeof defaultToDob): Array<number> {
+  const firstSix = getFirstSix(number);
+  const dob = toDob(firstSix);
+  const baseNumber = getBaseNumber(number);
+
+  if (isUnknownDob(dob))
+    return getChecksumBasesUnknownDob(baseNumber);
+
+  return getChecksumBasesForStandardDob(baseNumber, toDob);
+}
+
+function isValidChecksumPair(checksumBasis: number, checksum: number): boolean {
+  return !((checksumBasis + checksum) % 97);
+}
+
+export function validChecksum(number: string, toDob: typeof defaultToDob = defaultToDob): boolean {
+  const checksumBases = getChecksumBases(number, toDob);
+  const checksum = getChecksum(number);
+  return checksumBases.some(csb => isValidChecksumPair(csb, checksum));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,7 @@ export const personValidators: Record<string, Validator[]> = {
   AU: [AU.tfn],
   AZ: [AZ.pin, AZ.tin],
   BA: [BA.jmbg],
-  BE: [BE.nn],
+  BE: [BE.bis, BE.nn],
   BG: [BG.egn, BG.pnf, BG.vat],
   BR: [BR.cpf],
   BY: [BY.unp],

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,7 @@ export const personValidators: Record<string, Validator[]> = {
   AU: [AU.tfn],
   AZ: [AZ.pin, AZ.tin],
   BA: [BA.jmbg],
-  BE: [BE.bis, BE.nn],
+  BE: [BE.bis, BE.insz, BE.nn],
   BG: [BG.egn, BG.pnf, BG.vat],
   BR: [BR.cpf],
   BY: [BY.unp],


### PR DESCRIPTION
This work adds Belgium BIS and INSZ.

The BIS appears to be quite similar to the NN, except that the DOB month portion of the identifier is incremented by either 20 or 40.

I tried and could not find what 'BIS' stands for online.

This refactors the NN code so it can use an optional function for getting the DOB from the original number, and then uses that to implement BIS.

It appears that an INSZ number is either a BIS or NN, I wrote this validator in terms of the other two taking an 'invalid checksum' error over an 'invalid format' error if we get different errors as noted.