### PR TITLE
fix: fr/nif all 0s is not a valid value

### DIFF
--- a/src/fr/nif.spec.ts
+++ b/src/fr/nif.spec.ts
@@ -8,16 +8,16 @@ describe('fr/nif', () => {
     expect(result).toEqual('07 01 987 765 432');
   });
 
-  it('validate:3023217600053', () => {
-    const result = validate('302 321 7600 053');
+  test.each(['3023217600053', '0701987765493'])('validate:%s', value => {
+    const result = validate(value);
 
-    expect(result.isValid && result.compact).toEqual('3023217600053');
+    expect(result.isValid && result.compact).toEqual(value);
   });
 
-  it('validate:0701987765432', () => {
-    const result = validate('0701987765493');
+  test.each(['0000000000000'])('validate:%s', value => {
+    const result = validate(value);
 
-    expect(result.isValid && result.compact).toEqual('0701987765493');
+    expect(result.isValid).toEqual(false);
   });
 
   it('validate:12345678', () => {

--- a/src/fr/nif.ts
+++ b/src/fr/nif.ts
@@ -57,6 +57,11 @@ const impl: Validator = {
     const [prefix, check] = strings.splitAt(value, 10);
     const pvalue = parseInt(prefix, 10);
 
+    // A zero value is not a valid value
+    if (pvalue === 0) {
+      return { isValid: false, error: new exceptions.InvalidComponent() };
+    }
+
     if (String(pvalue % 511).padStart(3, '0') !== check) {
       return { isValid: false, error: new exceptions.InvalidChecksum() };
     }


### PR DESCRIPTION
Added functionality to #55 to handle 0s