### PR TITLE
fix: handle 13 digit personnummers

### DIFF
--- a/src/se/personnummer.spec.ts
+++ b/src/se/personnummer.spec.ts
@@ -14,6 +14,15 @@ describe('se/personnummer', () => {
     expect(result.isValid && result.compact).toEqual('880320-0016');
   });
 
+  test.each(['811228-9874', '670919-9530', '11900102-2384'])(
+    'validate:%s',
+    value => {
+      const result = validate(value);
+
+      expect(result.isValid).toEqual(true);
+    },
+  );
+
   it('validate:12345678', () => {
     const result = validate('12345678');
 

--- a/src/se/personnummer.ts
+++ b/src/se/personnummer.ts
@@ -54,10 +54,14 @@ const impl: Validator = {
     if (error) {
       return { isValid: false, error };
     }
-    if (value.length !== 11 && value.length !== 13) {
+    let a, b, c;
+    if (value.length === 11) {
+      [a, b, c] = strings.splitAt(value, -5, -4);
+    } else if (value.length === 13) {
+      [, a, b, c] = strings.splitAt(value, -11, -5, -4);
+    } else {
       return { isValid: false, error: new exceptions.InvalidLength() };
     }
-    const [a, b, c] = strings.splitAt(value, -5, -4);
     if (!'-+'.includes(b)) {
       return { isValid: false, error: new exceptions.InvalidFormat() };
     }


### PR DESCRIPTION
Fixes #93 -- remove the first 2 digits to handle the checksum correctly.