### PR TITLE
fix: French VAT checksum failing for leading zero

### DIFF
--- a/src/fr/tva.spec.ts
+++ b/src/fr/tva.spec.ts
@@ -19,6 +19,8 @@ describe('fr/tva', () => {
     '23334175221',
     'K7399859412',
     '4Z123456782',
+    '04494887854', // First digit of checksum is 0
+    'FR04494887854', // First digit of checksum is 0
     'FR84323140392',
   ])('validate:%s', value => {
     const result = validate(value);

--- a/src/fr/tva.ts
+++ b/src/fr/tva.ts
@@ -80,7 +80,7 @@ const impl: Validator = {
     if (strings.isdigits(check)) {
       const sum = (12 + 3 * (parseInt(back, 10) % 97)) % 97;
 
-      if (String(sum) !== check) {
+      if (sum !== parseInt(check, 10)) {
         return { isValid: false, error: new exceptions.InvalidChecksum() };
       }
     } else {


### PR DESCRIPTION
This is a valid French VAT number: `04813837531`.
The checksum bit is: `04`.
The sum is correctly being calculated as `4`, but validation fails when comparing `"4"` with `"04"`.

As a solution we compare numbers instead of strings.