### PR TITLE
fix: InvalidChecksum typo

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -35,7 +35,7 @@ export class InvalidFormat extends ValidationError {
  * The number's internal checksum or check digit does not match.
  */
 export class InvalidChecksum extends ValidationError {
-  constructor(msg = "The number number's checksum or check digit is invalid.") {
+  constructor(msg = "The number checksum or check digit is invalid.") {
     super(msg);
     this.name = 'InvalidChecksum';
   }


### PR DESCRIPTION
There is a minor typo in the `InvalidChecksum` exception where the error message says `The number number's checksum or check digit is invalid.`. This PR fixes that.

I wouldn't mind, but seems enough to bother some people seeing the error 🤷  