### PR TITLE
Fix NIF validation for Portugal.

### DIFF
--- a/src/pt/nif.spec.ts
+++ b/src/pt/nif.spec.ts
@@ -25,4 +25,16 @@ describe('pt/nif', () => {
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });
+
+  it('validate:PT 507 104 560', () => {
+    const result = validate('507104560');
+
+    expect(result.isValid && result.compact).toEqual('507104560');
+  });
+
+  it('validate:PT 506 035 220', () => {
+    const result = validate('506035220');
+
+    expect(result.isValid && result.compact).toEqual('506035220');
+  });
 });

--- a/src/pt/nif.ts
+++ b/src/pt/nif.ts
@@ -61,7 +61,7 @@ const impl: Validator = {
       modulus: 11,
     });
 
-    if (String((11 - sum) % 10) !== check) {
+    if (String((11 - sum) % 11 % 10) !== check) {
       return { isValid: false, error: new exceptions.InvalidChecksum() };
     }
 


### PR DESCRIPTION
Some valid NIF PT numbers are being marked as invalid by the library. A client reported this bug, so I added a few tests for this specific issue.

You can find more info at https://www.nif.pt/.