### PR TITLE
fix: format 8 digits chilean rut

### DIFF
--- a/src/cl/rut.spec.ts
+++ b/src/cl/rut.spec.ts
@@ -6,10 +6,16 @@ import {
 } from '../exceptions';
 
 describe('cl/rut', () => {
-  it('format:800280610', () => {
+  it('format:125319092', () => {
     const result = format('125319092');
 
     expect(result).toEqual('12.531.909-2');
+  });
+
+  it('format:77272305', () => {
+    const result = format('77272305');
+
+    expect(result).toEqual('7.727.230-5');
   });
 
   it('validate:76086428-5', () => {

--- a/src/cl/rut.ts
+++ b/src/cl/rut.ts
@@ -46,9 +46,7 @@ const impl: Validator = {
   format(input: string): string {
     const [value] = clean(input);
 
-    const [a, b, c, d] = strings.splitAt(value, 2, 5, 8);
-
-    return `${a}.${b}.${c}-${d}`;
+    return `${value.slice(0, -7)}.${value.slice(-7, -4)}.${value.slice(-4, -1)}-${value.slice(-1)}`;
   },
 
   /**


### PR DESCRIPTION
The current implementation of the format method does not support 8-digit RUTs (Chile), resulting in an unexpected undefined at the end. This type of RUT is common among people over 60 years old.

Current response: `"77.272.305-undefined"`
Expected: `"7.727.230-5"`