### PR TITLE
fix(sv/nit): align check digit logic with Python reference implementa…

### DIFF
--- a/src/sv/nit.spec.ts
+++ b/src/sv/nit.spec.ts
@@ -31,4 +31,24 @@ describe('sv/nit', () => {
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });
+
+  it('validate:0614-050707-001-1 (old NIT, sequential below 100)', () => {
+    // Sequential '001' <= '100' must use the old-NIT weights
+    const result = validate('0614-050707-001-1');
+
+    expect(result.isValid && result.compact).toEqual('06140507070011');
+  });
+
+  it('validate:0614-060707-101-0 (new NIT, weighted sum divisible by 11)', () => {
+    // Weighted sum % 11 === 0, so the check digit is (-0 % 11) % 10 = 0
+    const result = validate('0614-060707-101-0');
+
+    expect(result.isValid && result.compact).toEqual('06140607071010');
+  });
+
+  it('validate:0614-060707-101-1', () => {
+    const result = validate('0614-060707-101-1');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
 });

--- a/src/sv/nit.ts
+++ b/src/sv/nit.ts
@@ -84,7 +84,7 @@ const impl: Validator = {
     let sum;
     const [front, check] = strings.splitAt(value, 13);
 
-    if (value.substr(10, 3) <= '100') {
+    if (value.slice(10, 13) <= '100') {
       sum =
         weightedSum(front, {
           weights: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2],

--- a/src/sv/nit.ts
+++ b/src/sv/nit.ts
@@ -84,7 +84,7 @@ const impl: Validator = {
     let sum;
     const [front, check] = strings.splitAt(value, 13);
 
-    if (value.substr(10, 3) === '100') {
+    if (value.substr(10, 3) <= '100') {
       sum =
         weightedSum(front, {
           weights: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2],
@@ -92,11 +92,12 @@ const impl: Validator = {
         }) % 10;
     } else {
       sum =
-        (11 -
+        ((11 -
           weightedSum(front, {
             weights: [2, 7, 6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2],
             modulus: 11,
           })) %
+          11)%
         10;
     }
 

--- a/src/sv/nit.ts
+++ b/src/sv/nit.ts
@@ -97,7 +97,7 @@ const impl: Validator = {
             weights: [2, 7, 6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2],
             modulus: 11,
           })) %
-          11)%
+          11) %
         10;
     }
 


### PR DESCRIPTION
The TypeScript NIT validator diverged from the upstream python-stdnum implementation in two places, causing valid NITs to be rejected.

1. Old-vs-new NIT branch selection

   The condition used strict equality against the sequential block:

       value.substr(10, 3) === '100'

   The Python reference uses a lexicographic comparison:

       number[10:13] <= '100'

   As a result, any "old" NIT whose sequential block was below '100' (i.e. '000'–'099') was being validated with the new-NIT formula and incorrectly flagged as InvalidChecksum. Changed to `<= '100'` to match.

2. New-NIT check digit edge case

   The formula was:

       (11 - weightedSum(...)) % 10

   The Python equivalent is:

       (-total % 11) % 10

   which, expanded, is `((11 - total % 11) % 11) % 10`. The outer `% 11` matters: when the weighted sum is divisible by 11, Python returns 0 while the TS version returned 1, rejecting otherwise-valid numbers. Added the missing `% 11` step.

No changes to weights, length/format/component checks, or the SV-prefix handling. Verified against the docstring fixture `0614-050707-104-8`.