### PR TITLE
refactor: extract alphabetToNumber helper, optimize SSN blacklist lookup

### DIFF
--- a/src/us/ssn.ts
+++ b/src/us/ssn.ts
@@ -17,7 +17,7 @@ import * as exceptions from '../exceptions';
 import { strings } from '../util';
 import { Validator, ValidateReturn } from '../types';
 
-const invalidSSN = [
+const invalidSSNSet = new Set([
   '111111111',
   '222222222',
   '333333333',
@@ -27,7 +27,6 @@ const invalidSSN = [
   '888888888',
   '999999999',
   '123123123',
-  '999999999',
   // Used in Advertising and known "invalid"
   '002281852',
   '042103580',
@@ -51,7 +50,7 @@ const invalidSSN = [
   '457555462',
   '468288779',
   '549241889',
-];
+]);
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
   return strings.cleanUnicode(input, '- ');
@@ -94,7 +93,7 @@ const impl: Validator = {
     if (!strings.isdigits(value)) {
       return { isValid: false, error: new exceptions.InvalidComponent() };
     }
-    if (invalidSSN.includes(value)) {
+    if (invalidSSNSet.has(value)) {
       return { isValid: false, error: new exceptions.InvalidComponent() };
     }
     if (/^(000|666|9)\d+/.test(value)) {

--- a/src/util/checksum.ts
+++ b/src/util/checksum.ts
@@ -80,7 +80,6 @@ export function luhnChecksumValidate(
 
   const sum = value
     .split('')
-    // .reverse()
     .map(v => alphabet.indexOf(v))
     .reduce((acc, val, idx) => {
       let v = val;
@@ -214,31 +213,35 @@ function modulo(dividentIn: string, divisor: number) {
 }
 
 /**
+ * Convert a string using alphanumeric alphabet to its numeric representation.
+ * Returns null if any character is not in the alphabet.
+ */
+function alphabetToNumber(
+  value: string,
+  alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+): string | null {
+  let result = '';
+  for (const c of value) {
+    const idx = alphabet.indexOf(c);
+    if (idx === -1) {
+      return null;
+    }
+    result += String(idx);
+  }
+  return result;
+}
+
+/**
  * The ISO 7064 Mod 97, 10 algorithm.
  *
  * The Mod 97, 10 algorithm evaluates the whole number as an integer which is
  * valid if the number modulo 97 is 1. As such it has two check digits.
  */
 export function mod97base10Validate(value: string, expect = 1): boolean {
-  const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-  let fail = false;
-
-  const bigValue = value
-    .split('')
-    .map(c => {
-      const idx = alphabet.indexOf(c);
-      if (idx === -1) {
-        fail = true;
-        return '';
-      }
-      return String(idx);
-    })
-    .join('');
-
-  if (fail) {
+  const bigValue = alphabetToNumber(value);
+  if (bigValue === null) {
     return false;
   }
-
   return modulo(bigValue, 97) === expect;
 }
 


### PR DESCRIPTION
## Summary

Two small, behavior-preserving refactors verified with output-based regression testing (using the [Regrets](https://github.com/Wolfvin/Regrets) skill).

## Changes

### 1. `src/util/checksum.ts` — Extract `alphabetToNumber()` helper

- Extract the alphabet-to-number conversion logic from `mod97base10Validate()` into a dedicated `alphabetToNumber()` function
- Uses early-return pattern instead of mutable `fail` flag
- Cleaner iteration with `for-of` instead of `split().map().join()`
- The helper can be reused by other functions that need alphanumeric-to-numeric conversion

### 2. `src/us/ssn.ts` — Optimize blacklist lookup

- Convert `invalidSSN` array to `invalidSSNSet` (a `Set`) for O(1) lookup instead of O(n)
- Remove duplicate `999999999` entry from the blacklist
- Change `invalidSSN.includes(value)` to `invalidSSNSet.has(value)`

## Verification

All changes verified with 3 independent methods:

| Method | Result |
|--------|--------|
| Full test suite (1605 tests) | ✅ All passing |
| Regrets regression (7 clusters) | ✅ All GREEN |
| Raw output vs pre-refactor truth | ✅ Identical |
| Fingerprint cross-match | ✅ All match |

### Regrets Clusters Tested

1. `us-ssn-validate` — US SSN validation
2. `id-npwp-validate` — Indonesian NPWP validation
3. `br-cpf-validate` — Brazilian CPF validation
4. `gb-nino-validate` — UK NINO validation
5. `checksum-luhn` — Luhn checksum
6. `checksum-mod97` — ISO 7064 Mod 97,10
7. `checksum-mod11mod10` — ISO 7064 Mod 11,10

### Key Finding

I initially attempted to refactor `luhnChecksumValidate()` to delegate to `luhnChecksum()` (DRY principle). However, these two functions compute the Luhn algorithm differently — `luhnChecksum` reverses the string before processing while `luhnChecksumValidate` processes left-to-right. The refactoring broke 6 test suites immediately. This demonstrates the value of output-based regression testing for catching subtle behavioral differences.

I did NOT include this change since it alters behavior.