### PR TITLE
fix(bg/egn): validate the embedded birth date

### DIFF
--- a/src/bg/egn.spec.ts
+++ b/src/bg/egn.spec.ts
@@ -1,5 +1,9 @@
 import { validate, format } from './egn';
-import { InvalidLength, InvalidChecksum } from '../exceptions';
+import {
+  InvalidLength,
+  InvalidChecksum,
+  InvalidComponent,
+} from '../exceptions';
 
 describe('bg/egn', () => {
   it('format:752316 926 3', () => {
@@ -24,5 +28,20 @@ describe('bg/egn', () => {
     const result = validate('8032056032');
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  // The first six digits are a birth date whose month encodes the century
+  // (41-52 -> 2000s, 21-32 -> 1800s); an impossible date must be rejected even
+  // when the check digit is correct.
+  it('validate:2992070971 (impossible month, valid check digit)', () => {
+    const result = validate('2992070971');
+
+    expect(result.error).toBeInstanceOf(InvalidComponent);
+  });
+
+  it('validate:8019010008 (impossible month)', () => {
+    const result = validate('8019010008');
+
+    expect(result.error).toBeInstanceOf(InvalidComponent);
   });
 });

--- a/src/bg/egn.ts
+++ b/src/bg/egn.ts
@@ -54,14 +54,16 @@ const impl: Validator = {
     // The first six digits are the birth date. The month encodes the century:
     // 41-52 -> 2000s, 21-32 -> 1800s, 01-12 -> 1900s.
     const [yy, mm, dd] = strings.splitAt(value, 2, 4, 6);
-    let year = parseInt(yy, 10) + 1900;
+    let year = parseInt(yy, 10);
     let month = parseInt(mm, 10);
     if (month > 40) {
-      year += 100;
+      year += 2000;
       month -= 40;
     } else if (month > 20) {
-      year -= 100;
+      year += 1800;
       month -= 20;
+    } else {
+      year += 1900;
     }
     if (!isValidDate(String(year), String(month), dd)) {
       return { isValid: false, error: new exceptions.InvalidComponent() };

--- a/src/bg/egn.ts
+++ b/src/bg/egn.ts
@@ -10,7 +10,7 @@
  */
 
 import * as exceptions from '../exceptions';
-import { strings } from '../util';
+import { isValidDate, strings } from '../util';
 import { Validator, ValidateReturn } from '../types';
 import { weightedSum } from '../util/checksum';
 
@@ -49,6 +49,22 @@ const impl: Validator = {
     }
     if (!strings.isdigits(value)) {
       return { isValid: false, error: new exceptions.InvalidFormat() };
+    }
+
+    // The first six digits are the birth date. The month encodes the century:
+    // 41-52 -> 2000s, 21-32 -> 1800s, 01-12 -> 1900s.
+    const [yy, mm, dd] = strings.splitAt(value, 2, 4, 6);
+    let year = parseInt(yy, 10) + 1900;
+    let month = parseInt(mm, 10);
+    if (month > 40) {
+      year += 100;
+      month -= 40;
+    } else if (month > 20) {
+      year -= 100;
+      month -= 20;
+    }
+    if (!isValidDate(String(year), String(month), dd)) {
+      return { isValid: false, error: new exceptions.InvalidComponent() };
     }
 
     const [front, check] = strings.splitAt(value, -1);


### PR DESCRIPTION
### Problem

The first six digits of a Bulgarian EGN are a birth date whose month encodes the century (`41-52` → 2000s, `21-32` → 1800s, `01-12` → 1900s). `validate()` only checked the length, that the value is all digits, and the check digit — it never validated the date. A number with an **impossible date but a correct check digit** was accepted:

```js
validate('2992070971'); // month "92" -> { isValid: true }
```

`python-stdnum` (the reference this library tracks) rejects these as `InvalidComponent`, and its own docstring uses `8019010008` as an "invalid date" example.

### Fix

Decode the century from the month and validate the date with the existing `isValidDate` helper, before the check-digit step (matching the reference's order). This mirrors `python-stdnum`'s `get_birth_date`.

Verified differentially against `python-stdnum` over 50,000 random 10-digit inputs: **0 disagreements** after the change (before, JS accepted invalid-date numbers that python rejects).

### Tests

Added two cases to `bg/egn.spec.ts`: an impossible month with a valid check digit (`2992070971`) and python-stdnum's documented invalid-date example (`8019010008`), both expecting `InvalidComponent`. They fail before the change and pass after. Full suite is green except one pre-existing, unrelated `mx/curp` date failure present on `main`. `eslint` + `prettier --check` clean.