### PR TITLE
fix(ie/pps): accept 'B' as second letter (2024 rule)

### DIFF
--- a/src/ie/pps.spec.ts
+++ b/src/ie/pps.spec.ts
@@ -38,6 +38,12 @@ describe('ie/pps', () => {
     expect(result.isValid && result.compact).toEqual('6433435IH');
   });
 
+  it('validate:1234567OB', () => {
+    const result = validate('1234567OB');
+
+    expect(result.isValid && result.compact).toEqual('1234567OB');
+  });
+
   it('validate:12345678', () => {
     const result = validate('1234567891');
 

--- a/src/ie/pps.ts
+++ b/src/ie/pps.ts
@@ -6,8 +6,9 @@
  * When present (which should be the case for new numbers as of 2013),
  * the second letter can be 'A' (for individuals) or 'H' (for
  * non-individuals, such as limited companies, trusts, partnerships
- * and unincorporated bodies). Pre-2013 values may have 'W', 'T',
- * or 'X' as the second letter ; it is ignored by the check.
+ * and unincorporated bodies). As of 2024, 'B' was accepted as a
+ * second letter on all new PPS numbers. Pre-2013 values may have
+ * 'W', 'T', or 'X' as the second letter ; it is ignored by the check.
  *
  * Source
  *
@@ -23,7 +24,7 @@ function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
   return strings.cleanUnicode(input, ' -');
 }
 
-const ppsRe = /^\d{7}[A-W][AHWTX]?$/;
+const ppsRe = /^\d{7}[A-W][ABHWTX]?$/;
 
 const impl: Validator = {
   name: 'Irish Personal Number',
@@ -58,7 +59,7 @@ const impl: Validator = {
       return { isValid: false, error: new exceptions.InvalidFormat() };
     }
 
-    if (value.length === 9 && 'AH'.includes(value[8])) {
+    if (value.length === 9 && 'ABH'.includes(value[8])) {
       if (
         value[7] !== calcCheckDigit(`${value.substr(0, 7)}${value.substr(8)}`)
       ) {


### PR DESCRIPTION
Ireland began issuing PPS numbers with `B` as the second letter on all new numbers as of 2024. The syntax regex omits `B` and the 2013-format check-digit branch only recognises `A`/`H`, so a valid number such as `1234567OB` is rejected with `InvalidFormat`.

Align the regex (`[ABHWTX]?`) and the check-digit branch (`ABH`) with the current rule, matching the upstream python-stdnum reference (`validate('1234567OB')` → `'1234567OB'`).
