### PR TITLE
fix(fo/vn): strip the FO prefix in compact

### DIFF
--- a/src/fo/vn.spec.ts
+++ b/src/fo/vn.spec.ts
@@ -14,6 +14,12 @@ describe('fo/vn', () => {
     expect(result.isValid && result.compact).toEqual('623857');
   });
 
+  it('validate:FO384941', () => {
+    const result = validate('FO384941');
+
+    expect(result.isValid && result.compact).toEqual('384941');
+  });
+
   test.each(['623857', '33 28 28', '563.609'])('validate:%s', value => {
     const result = validate(value);
 

--- a/src/fo/vn.ts
+++ b/src/fo/vn.ts
@@ -16,7 +16,7 @@ import { strings } from '../util';
 import { Validator, ValidateReturn } from '../types';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
-  return strings.cleanUnicode(input, ' -.');
+  return strings.cleanUnicode(input, ' -.', 'FO');
 }
 
 // const validRe = /^[PCGQV]{1}00[A-Z0-9]{8}$/;


### PR DESCRIPTION
Faroe Islands V-numbers are frequently written with the `FO` country prefix (e.g. `FO384941`). `compact` does not remove it, so the value is 8 characters and validation fails with `InvalidLength`.

Strip a leading `FO` in `clean`, following the same approach already used for the `BE` prefix in `be/vat` and matching the upstream python-stdnum reference (`validate('FO384941')` → `'384941'`).
