### PR TITLE
fix(pe/cui): allow a letter as the optional check digit

### DIFF
--- a/src/pe/cui.spec.ts
+++ b/src/pe/cui.spec.ts
@@ -14,6 +14,12 @@ describe('pe/cui', () => {
     expect(result.isValid && result.compact).toEqual('101174102');
   });
 
+  it('validate:10812543-H', () => {
+    const result = validate('10812543-H');
+
+    expect(result.isValid && result.compact).toEqual('10812543H');
+  });
+
   it('validate:1011741', () => {
     const result = validate('1011741');
 

--- a/src/pe/cui.ts
+++ b/src/pe/cui.ts
@@ -54,7 +54,7 @@ const impl: Validator = {
     if (value.length !== 8 && value.length !== 9) {
       return { isValid: false, error: new exceptions.InvalidLength() };
     }
-    if (!strings.isdigits(value)) {
+    if (!strings.isdigits(value.substr(0, 8))) {
       return { isValid: false, error: new exceptions.InvalidFormat() };
     }
 


### PR DESCRIPTION
A Peruvian CUI's optional check character can be a letter (`K…A`) as well as a digit; the two possible check characters are already computed, but the format guard applies `isdigits` to the entire value, so a valid number such as `10812543-H` is rejected with `InvalidFormat` before the checksum is evaluated.

Restrict the digit check to the first 8 characters, matching python-stdnum's `isdigits(number[:8])`, so the existing check-digit logic can evaluate the letter (`validate('10812543-H')` → `'10812543H'`).
