### PR TITLE
fix(mx/rfc): do not enforce check digit, matching python-stdnum default behavior

### DIFF
--- a/src/mx/rfc.spec.ts
+++ b/src/mx/rfc.spec.ts
@@ -37,11 +37,13 @@ describe('mx/rfc', () => {
     expect(result.isValid && result.compact).toEqual('SALC7304253S0');
   });
 
-  // it('validate:XEXX010101000', () => {
-  //   const result = validate('XEXX010101000');
+  it('validate:XEXX010101000', () => {
+    // Generic RFC for foreign residents; its serial/check digits do not
+    // follow the check digit algorithm but it is a real, valid RFC
+    const result = validate('XEXX010101000');
 
-  //   expect(result.isValid && result.compact).toEqual('XEXX010101000');
-  // });
+    expect(result.isValid && result.compact).toEqual('XEXX010101000');
+  });
 
   it('validate:RET130705MD5', () => {
     const result = validate('RET130705MD5');
@@ -56,9 +58,19 @@ describe('mx/rfc', () => {
   });
 
   it('validate:VACE-460910-SX6', () => {
+    // python-stdnum docstring example: fails the check digit algorithm but
+    // is accepted because check digit validation is disabled by default
     const result = validate('VACE-460910-SX6');
 
-    expect(result.isValid).toEqual(false);
+    expect(result.isValid && result.compact).toEqual('VACE460910SX6');
+  });
+
+  it('validate:PAF-070213-GI1', () => {
+    // SAT-issued company RFC whose check digit does not match the published
+    // algorithm (expected 'A'); must validate like python-stdnum does
+    const result = validate('PAF-070213-GI1');
+
+    expect(result.isValid && result.compact).toEqual('PAF070213GI1');
   });
 
   it('validate:SOTO800101110', () => {

--- a/src/mx/rfc.ts
+++ b/src/mx/rfc.ts
@@ -29,7 +29,7 @@
  */
 
 import * as exceptions from '../exceptions';
-import { isValidDateCompactYYMMDD, strings, weightedSum } from '../util';
+import { isValidDateCompactYYMMDD, strings } from '../util';
 import { Validator, ValidateReturn } from '../types';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
@@ -79,13 +79,6 @@ const nameBlacklist = new Set([
   'RATA',
   'RUIN',
 ]);
-
-// Official alphabet per SAT (Anexo 20). Includes '&' and 'Ñ'.
-const checkAlphabet = '0123456789ABCDEFGHIJKLMN&OPQRSTUVWXYZ Ñ';
-
-// Legacy alphabet (Base 36) used in older systems.
-// It excludes '&' and 'Ñ'. Space is added to support padding for companies.
-const checkAlphabetLegacy = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ ';
 
 const impl: Validator = {
   name: 'Mexican Tax Number',
@@ -143,42 +136,6 @@ const impl: Validator = {
       }
     } else {
       return { isValid: false, error: new exceptions.InvalidLength() };
-    }
-
-    if (value.length >= 12) {
-      if (!/[1-9A-V][1-9A-Z][0-9A]$/.test(value)) {
-        return { isValid: false, error: new exceptions.InvalidComponent() };
-      }
-
-      const [front, check] = strings.splitAt(value, -1);
-      const paddedInput = front.padStart(12, ' ');
-
-      const calculateChecksum = (alphabet: string) => {
-        const sum = weightedSum(paddedInput, {
-          modulus: 11,
-          alphabet: alphabet,
-          weights: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-          reverse: true,
-        });
-
-        const mod = 11 - (sum % 11);
-        if (mod === 11) return '0';
-        if (mod === 10) return 'A';
-        return String(mod);
-      };
-
-      // Try with official SAT alphabet first
-      const valOfficial = calculateChecksum(checkAlphabet);
-
-      if (check !== valOfficial) {
-        // If it fails, try with Legacy alphabet (Base 36)
-        // This handles older RFCs generated without '&' or 'Ñ' support
-        const valLegacy = calculateChecksum(checkAlphabetLegacy);
-
-        if (check !== valLegacy) {
-          return { isValid: false, error: new exceptions.InvalidChecksum() };
-        }
-      }
     }
 
     return {


### PR DESCRIPTION
## Problem

`validate()` rejects real, SAT-issued RFCs with `InvalidChecksum`. Example: **PAF070213GI1** (a company RFC in active use) — the published check digit algorithm computes `A` for it, but SAT issued it with `1`.

python-stdnum accepts this number. Its `mx.rfc` module deliberately **skips check digit verification by default** because the algorithm does not hold for a significant share of real numbers:

> However, it seems a lot of numbers (estimated at around 1.5% of all numbers) are in use with invalid check digits so this test is disabled by default.

python-stdnum only checks the digit when the caller opts in via `validate(number, validate_check_digits=True)`. Its own docstring example `VACE-460910-SX6` validates by default and only fails under the opt-in flag.

The TypeScript port enforces the check digit unconditionally, which also contradicts this module's own documentation:

- the file header carries the same "disabled by default" note quoted above, and
- the `validate()` JSDoc says *"It does not check for control letter"*.

## Change

- Remove the unconditional check digit verification from `validate()` (including the legacy-alphabet fallback added in #143, which was working around the same underlying issue but cannot cover numbers like this one), and the `[1-9A-V][1-9A-Z][0-9A]` serial pattern check that python-stdnum also applies only under the opt-in flag.
- Update the `VACE-460910-SX6` expectation to valid, matching the python-stdnum docstring.
- Re-enable the previously commented-out `XEXX010101000` test (the official generic RFC for foreign residents) — it now passes.
- Add a regression test for `PAF-070213-GI1`.

Length, format/regex, blacklist, and date validation are unchanged.

## Verification

- `PAF070213GI1`, `VACE460910SX6`, and `XEXX010101000` all cross-checked against python-stdnum's `stdnum.mx.rfc.validate` (valid by default; `PAF...`/`VACE...` fail only with `validate_check_digits=True`, matching the removed behavior).
- The three test changes fail on `main` and pass with this fix; full suite: 1613 passed, 1613 total. Prettier + ESLint clean.

If strict check digit validation is still wanted as an opt-in (like python-stdnum's flag), I'm happy to add it in a follow-up — but the default should not reject genuine RFCs.