### PR TITLE
fix: accept numbers written with their usual separators (se, cl, uy)

### DIFF
--- a/src/cl/rut.spec.ts
+++ b/src/cl/rut.spec.ts
@@ -30,8 +30,34 @@ describe('cl/rut', () => {
     expect(result.isValid && result.compact).toEqual('125319092');
   });
 
+  // The number is normally printed with the thousands separators, which is
+  // also what format() emits.
+  it('validate:12.531.909-2', () => {
+    const result = validate('12.531.909-2');
+
+    expect(result.isValid && result.compact).toEqual('125319092');
+  });
+
+  it('validate:CL 7.727.230-5', () => {
+    const result = validate('CL 7.727.230-5');
+
+    expect(result.isValid && result.compact).toEqual('77272305');
+  });
+
+  it('validate:format:76086428-5', () => {
+    const result = validate(format('76086428-5'));
+
+    expect(result.isValid && result.compact).toEqual('760864285');
+  });
+
   it('validate:12531909-3', () => {
     const result = validate('12531909-3');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:12.531.909-3', () => {
+    const result = validate('12.531.909-3');
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });

--- a/src/cl/rut.ts
+++ b/src/cl/rut.ts
@@ -16,7 +16,7 @@ import { strings, weightedSum } from '../util';
 import { Validator, ValidateReturn } from '../types';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
-  const [v, err] = strings.cleanUnicode(input, ' -');
+  const [v, err] = strings.cleanUnicode(input, ' -.');
 
   if (err) {
     return ['', err];

--- a/src/se/personnummer.spec.ts
+++ b/src/se/personnummer.spec.ts
@@ -38,6 +38,21 @@ describe('se/personnummer', () => {
     },
   );
 
+  // The separator is only written between the birth date and the birth number,
+  // it is not part of the number (Folkbokföringslagen 1991:481 §18), so the
+  // bare 10 and 12 digit forms are valid too.
+  test.each([
+    ['8803200016', '880320-0016'],
+    ['8112289874', '811228-9874'],
+    ['6709199530', '670919-9530'],
+    ['7010632391', '701063-2391'], // coordination number
+    ['119001022384', '900102+2384'], // 4digit year, no hyphen
+  ])('validate:%s', (given, want) => {
+    const result = validate(given);
+
+    expect(result.isValid && result.compact).toEqual(want);
+  });
+
   it('validate:12345678', () => {
     const result = validate('12345678');
 
@@ -46,6 +61,18 @@ describe('se/personnummer', () => {
 
   it('validate:880320-0018', () => {
     const result = validate('880320-0018');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:8803200018', () => {
+    const result = validate('8803200018');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:198803200018', () => {
+    const result = validate('198803200018');
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });

--- a/src/se/personnummer.ts
+++ b/src/se/personnummer.ts
@@ -26,7 +26,16 @@ function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
     return [value, err];
   }
 
-  const [a, b, c] = strings.splitAt(value, -5, -4);
+  // A 10 or 12 digit number is written without the separator, so put the
+  // default one back. '-' is only replaced by '+' the year someone turns 100,
+  // which the bare form cannot express.
+  const separated =
+    (value.length === 10 || value.length === 12) &&
+    !'-+'.includes(value[value.length - 5])
+      ? `${value.slice(0, -4)}-${value.slice(-4)}`
+      : value;
+
+  const [a, b, c] = strings.splitAt(separated, -5, -4);
 
   return [`${a.replace(/[-+]/g, '')}${b}${c}`, null];
 }

--- a/src/uy/cedula.spec.ts
+++ b/src/uy/cedula.spec.ts
@@ -14,6 +14,19 @@ describe('uy/cedula', () => {
     expect(result.isValid && result.compact).toEqual('12345672');
   });
 
+  // The cédula is printed as a.bcd.efg-h, which is also what format() emits.
+  it('validate:1.234.567-2', () => {
+    const result = validate('1.234.567-2');
+
+    expect(result.isValid && result.compact).toEqual('12345672');
+  });
+
+  it('validate:format:12345672', () => {
+    const result = validate(format('12345672'));
+
+    expect(result.isValid && result.compact).toEqual('12345672');
+  });
+
   it('validate:1121123', () => {
     const result = validate('1121123');
 
@@ -22,6 +35,12 @@ describe('uy/cedula', () => {
 
   it('validate:12345673', () => {
     const result = validate('12345673');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:1.234.567-3', () => {
+    const result = validate('1.234.567-3');
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });

--- a/src/uy/cedula.ts
+++ b/src/uy/cedula.ts
@@ -9,7 +9,7 @@ import { strings, weightedSum } from '../util';
 import { Validator, ValidateReturn } from '../types';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
-  return strings.cleanUnicode(input, ' -/');
+  return strings.cleanUnicode(input, ' -/.');
 }
 
 const impl: Validator = {

--- a/src/uy/nie.spec.ts
+++ b/src/uy/nie.spec.ts
@@ -14,6 +14,18 @@ describe('uy/nie', () => {
     expect(result.isValid && result.compact).toEqual('912345670');
   });
 
+  it('validate:91.234.567-0', () => {
+    const result = validate('91.234.567-0');
+
+    expect(result.isValid && result.compact).toEqual('912345670');
+  });
+
+  it('validate:format:912345670', () => {
+    const result = validate(format('912345670'));
+
+    expect(result.isValid && result.compact).toEqual('912345670');
+  });
+
   it('validate:1121123', () => {
     const result = validate('1121123');
 
@@ -22,6 +34,12 @@ describe('uy/nie', () => {
 
   it('validate:912345673', () => {
     const result = validate('912345673');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
+
+  it('validate:91.234.567-3', () => {
+    const result = validate('91.234.567-3');
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });

--- a/src/uy/nie.ts
+++ b/src/uy/nie.ts
@@ -18,7 +18,7 @@ import { strings, weightedSum } from '../util';
 import { Validator, ValidateReturn } from '../types';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
-  return strings.cleanUnicode(input, ' -');
+  return strings.cleanUnicode(input, ' -.');
 }
 
 const impl: Validator = {


### PR DESCRIPTION
`clean()` in four modules doesn't normalise the input to the shape `validate()`'s length check expects, so each rejects the identifier as it is normally written.

**`se/personnummer`** requires the separator, so the bare 10- and 12-digit forms are `InvalidLength` — though `format()` has always accepted them:

```
validate('880320-0016')  -> OK            // already in the tests
validate('8803200016')   -> InvalidLength
validate('198803200016') -> InvalidLength
format('8803200016')     -> '880320-0016'
```

Per Folkbokföringslagen (1991:481) §18 the number *contains* "födelsetid, födelsenummer och kontrollsiffra" — the hyphen is written between them (and becomes `+` the year someone turns 100), so it isn't part of the number. `python-stdnum`'s `se.personnummer.compact()` inserts the default `-` at those two lengths; that step wasn't ported. Finishes #97 on the `validate()` side.

**`cl/rut`, `uy/cedula`, `uy/nie`** don't strip the `.` their own `format()` emits, so `validate(format('125319092'))`, `validate(format('12345672'))` and `validate(format('912345670'))` are all `InvalidLength`.

These are the only four: I checked all 198 modules by re-running every valid example in the specs through `python-stdnum` in 8 written forms, by `validate(format(x))`/`validate(compact(x))`, and by feeding `python-stdnum`'s canonical `format()` back in. All three probes are empty afterwards. Where the port is deliberately ahead of `python-stdnum` I left it — `tw/ubn` (#159) and samordningsnummer, which upstream still rejects.

Tests reuse existing fixtures with only the separator changed, plus a bad check digit in each new form. `npm test` 1627 pass (+17); the `mx/curp` failure is pre-existing on `main`.
