### PR TITLE
fix(ar/cbu): accept valid CBUs whose check digit is 0

### DIFF
--- a/src/ar/cbu.spec.ts
+++ b/src/ar/cbu.spec.ts
@@ -25,4 +25,25 @@ describe('ar/cbu', () => {
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });
+
+  // Regression: a check digit of 0 must be accepted. `10 - weightedSum(...)` yields
+  // 10 (not 0) when the weighted sum is 0, so without the `% 10` wrap these valid
+  // numbers were wrongly rejected as InvalidChecksum.
+  it('validate:0720429088000002339140', () => {
+    const result = validate('0720429088000002339140');
+
+    expect(result.isValid && result.compact).toEqual('0720429088000002339140');
+  });
+
+  it('validate:0000000000000000000000', () => {
+    const result = validate('0000000000000000000000');
+
+    expect(result.isValid && result.compact).toEqual('0000000000000000000000');
+  });
+
+  it('validate:0720429088000002339141', () => {
+    const result = validate('0720429088000002339141');
+
+    expect(result.error).toBeInstanceOf(InvalidChecksum);
+  });
 });

--- a/src/ar/cbu.ts
+++ b/src/ar/cbu.ts
@@ -63,20 +63,22 @@ const impl: Validator = {
     const [front, c1, back, c2] = strings.splitAt(value, 7, 8, 21);
 
     const s1 = String(
-      10 -
+      (10 -
         weightedSum(front, {
           reverse: true,
           weights: [3, 1, 7, 9, 3, 1, 7],
           modulus: 10,
-        }),
+        })) %
+        10,
     );
     const s2 = String(
-      10 -
+      (10 -
         weightedSum(back, {
           reverse: true,
           weights: [3, 1, 7, 9, 3, 1, 7, 9, 3, 1, 7, 9, 3, 1],
           modulus: 10,
-        }),
+        })) %
+        10,
     );
 
     if (s1 !== c1 || s2 !== c2) {


### PR DESCRIPTION
## Problem

`AR.cbu` rejects **valid** CBUs whenever either of the two check digits is `0`.

```js
const { stdnum } = require('stdnum');

stdnum.AR.cbu.validate('0720429088000002339140');
// => { isValid: false, error: InvalidChecksum }   ❌ this CBU is valid

stdnum.AR.cbu.validate('0000000000000000000000');
// => { isValid: false, error: InvalidChecksum }   ❌ both check digits are 0
```

## Root cause

In `src/ar/cbu.ts` the check digits are computed as:

```ts
const s1 = String(
  10 -
    weightedSum(front, { reverse: true, weights: [3, 1, 7, 9, 3, 1, 7], modulus: 10 }),
);
```

`weightedSum(..., { modulus: 10 })` already returns a value in `[0, 9]`, so `10 - that`
is in `[1, 10]`. When `weightedSum` returns `0`, `10 - 0 === 10` and `String(10)` is
`"10"`, which can never equal the single-character check digit `c1`/`c2` (`"0"`). Any CBU
whose bank block or account block has a check digit of `0` is therefore rejected.

Worked example for `0720429088000002339140`:

- front `0720429`, `c1 = "0"`, `weightedSum(front) = 0` → `s1 = "10"` (should be `"0"`)
- back `8800000233914`, `c2 = "0"`, `weightedSum(back) = 0` → `s2 = "10"` (should be `"0"`)

## Fix

Wrap the result modulo 10 — the same thing the sibling `src/mx/clabe.ts` validator
already does (`(10 - weightedSum(...)) % 10`), so this just brings `ar/cbu` in line with it.

## Tests

Added three cases to `src/ar/cbu.spec.ts`:

- `0720429088000002339140` — both check digits `0` → now valid
- `0000000000000000000000` — both check digits `0` → now valid
- `0720429088000002339141` — tampered → still `InvalidChecksum`

Full suite passes (`npx jest`), lint and prettier are clean.
