### PR TITLE
fix(ec/ruc): do not enforce mod-11 check digit on company RUCs

### DIFF
--- a/src/ec/ruc.spec.ts
+++ b/src/ec/ruc.spec.ts
@@ -1,5 +1,9 @@
 import { validate, format } from './ruc';
-import { InvalidLength, InvalidChecksum } from '../exceptions';
+import {
+  InvalidLength,
+  InvalidChecksum,
+  InvalidComponent,
+} from '../exceptions';
 
 describe('ec/ruc', () => {
   it('format:1792060346001', () => {
@@ -29,9 +33,30 @@ describe('ec/ruc', () => {
     expect(result.error).toBeInstanceOf(InvalidLength);
   });
 
-  it('validate:1792060347-001', () => {
-    const result = validate('1792060347-001');
+  // Company RUCs are issued by SRI without a check-digit algorithm, so
+  // numbers that fail the historical mod-11 scheme are still valid.
+  test.each(['1792060347001', '0993381661001', '1760001550001'])(
+    'validate:%s',
+    value => {
+      const result = validate(value);
+
+      expect(result.isValid).toEqual(true);
+    },
+  );
+
+  it('validate:0926687851-001', () => {
+    // Natural-person RUC with an invalid cedula check digit
+    const result = validate('0926687851-001');
 
     expect(result.error).toBeInstanceOf(InvalidChecksum);
   });
+
+  test.each(['0993381661000', '1760001550000', '2593381661001'])(
+    'validate-invalid-component:%s',
+    value => {
+      const result = validate(value);
+
+      expect(result.error).toBeInstanceOf(InvalidComponent);
+    },
+  );
 });

--- a/src/ec/ruc.ts
+++ b/src/ec/ruc.ts
@@ -4,15 +4,21 @@
  * The RUC is a tax identification number for legal entities. It has 13 digits
  * where the third digit is a number denoting the type of entity.
  *
- * Source
+ * Company RUCs (third digit 6 = public, 9 = private/juridical) are issued by
+ * the SRI without any check-digit algorithm, so only structural checks apply
+ * to them; the historical mod-11 scheme rejects real registry-valid numbers.
+ * Cedula-based RUCs (third digit 0-5) do carry the cedula's check digit.
  *
+ * Source
+ *   https://minka.gob.ec/mintel/ge/rutr/gobec_forms/-/issues/32
+ *   https://www.sri.gob.ec/en/web/intersri/consulta-al-ruc
  *
  * TAX/VAT
  */
 
 import * as exceptions from '../exceptions';
 import * as ci from './ci';
-import { strings, weightedSum } from '../util';
+import { strings } from '../util';
 import { Validator, ValidateReturn } from '../types';
 
 function clean(input: string): ReturnType<typeof strings.cleanUnicode> {
@@ -67,38 +73,18 @@ const impl: Validator = {
     }
 
     if (value[2] === '6') {
-      // Public RUC
-      const [front, end] = strings.splitAt(value, 9);
+      // Public RUC: SRI issues these without a check-digit algorithm, so
+      // only the establishment number is checked.
+      const [, end] = strings.splitAt(value, 9);
       if (end === '0000') {
         return { isValid: false, error: new exceptions.InvalidComponent() };
       }
-
-      if (
-        weightedSum(front, {
-          weights: [3, 2, 7, 6, 5, 4, 3, 2, 1],
-          modulus: 11,
-        }) !== 0
-      ) {
-        // If it's not a public, try natural
-        if (end.endsWith('000')) {
-          return { isValid: false, error: new exceptions.InvalidComponent() };
-        }
-
-        return ci.validate(value.substring(0, 10));
-      }
     } else if (value[2] === '9') {
-      // Juridical RUC
-      const [front, end] = strings.splitAt(value, 10);
+      // Juridical RUC: SRI issues these without a check-digit algorithm, so
+      // only the establishment number is checked.
+      const [, end] = strings.splitAt(value, 10);
       if (end === '000') {
         return { isValid: false, error: new exceptions.InvalidComponent() };
-      }
-      if (
-        weightedSum(front, {
-          weights: [4, 3, 2, 7, 6, 5, 4, 3, 2, 1],
-          modulus: 11,
-        }) !== 0
-      ) {
-        return { isValid: false, error: new exceptions.InvalidChecksum() };
       }
     } else {
       return { isValid: false, error: new exceptions.InvalidComponent() };


### PR DESCRIPTION
## Problem

`EC.ruc.validate` rejects real, registry-valid Ecuadorian company RUCs with `InvalidChecksum`. Example: `0993381661001` fails the mod-11 weighted sum (`[4,3,2,7,6,5,4,3,2,1]` → 159, 159 mod 11 = 5 ≠ 0) but is a valid taxpayer per SRI's official lookup (https://srienlinea.sri.gob.ec/sri-en-linea/SriRucWeb/ConsultaRuc/Consultas/consultaRuc).

## Why

The mod-11 check-digit scheme for company RUCs is a historical/community algorithm. The SRI has clarified that RUCs issued to private companies (third digit 9), public companies (third digit 6), and foreign natural persons **are not generated with any algorithm**, and check-digit validation has never been a requirement — see the SRI statement quoted in https://minka.gob.ec/mintel/ge/rutr/gobec_forms/-/issues/32. The SRI's own e-invoicing scheme added an explicit exception to skip mod-11 validation for these numbers. Only cédula-based RUCs (third digit 0–5) carry a reliable check digit, because the cédula itself has one.

python-stdnum has the same issue; other implementations (e.g. Odoo's Ecuadorian localization) dropped the company-RUC checksum for this same reason.

## Change

- Third digit 6 (public) and 9 (juridical): skip the mod-11 checksum; keep structural validation (13 digits, valid province prefix, establishment number ≠ `0000`/`000`). The 6-branch fallback to cédula validation is gone with the checksum that triggered it.
- Third digit 0–5 (natural person): unchanged — still validates the cédula check digit via `ec/ci`.
- Spec updated: the case `1792060347-001` asserted `InvalidChecksum` for an off-by-one tenth digit on a juridical RUC — that is exactly the false invariant, so it now asserts valid; added SRI-valid company RUCs (`0993381661001`, `1760001550001`), an `InvalidChecksum` case on a natural-person RUC, and `InvalidComponent` cases (establishment `000`/`0000`, bad province).

All 1641 tests pass; lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgezMx4ZYyFgH8u4hgjsZ8